### PR TITLE
Feat/30/upgrade terraform

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,4 +37,4 @@ Example: steps to reproduce the behavior:
 Note: List of related links and updated docs (READMEs, Notion, Google Docs, others links, etc).
 -->
 
-- [README](/my-tooling/my-ez-cli#readme)
+- [README](/DavidCardoso/my-ez-cli#readme)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 My Tooling
+Copyright (c) 2022 David Cardoso <dev+github@davidcardoso.me>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ Tools via **Unix Command Line Interface** with no installation and just using **
       - [Yarn Berry (v2+)](#yarn-berry-v2)
     - [Serverless Framework](#serverless-framework)
     - [Terraform](#terraform)
-      - [CONTEXT variable](#context-variable)
+      - [`CONTEXT` variable](#context-variable)
+      - [`DOTENV_FILE` variable](#dotenv_file-variable)
+      - [`TF_RC_FILE` variable](#tf_rc_file-variable)
+      - [`AWS_CREDENTIALS_FOLDER` variable](#aws_credentials_folder-variable)
+      - [`GCLOUD_CREDENTIALS_FOLDER` and `GOOGLE_APPLICATION_CREDENTIALS` variables](#gcloud_credentials_folder-and-google_application_credentials-variables)
     - [Ookla Speedtest CLI](#ookla-speedtest-cli)
     - [Google Cloud CLI](#google-cloud-cli)
     - [Graph Viz for docker compose](#graph-viz-for-docker-compose)
@@ -118,7 +122,6 @@ yarn init
 
 # install a package as dev dependency
 yarn add some-pkg --dev
-
 
 # install a package globally
 yarn global add another-pkg
@@ -230,6 +233,102 @@ terraform apply tfplan
 # destroy created resources on the providers
 # warning: do not run it in production! ;D
 terraform destroy
+```
+
+#### `CONTEXT` variable
+
+By default, the parent directory is mounted on the container.
+This allows files inside parent folder to be referenced in the Terraform files.
+
+For instance, if you need to use a Terraform `module` that is located two levels up
+in the filesystem, you can use `CONTEXT` variable before the `terraform` command
+to define the absolute path to that module (or another folder).
+
+```shell
+# option 1
+CONTEXT=$(cd "$PWD/../../" && pwd) terraform --version
+CONTEXT=$(cd "$PWD/../../" && pwd) terraform init
+
+# option 2
+CONTEXT=$(cd "$PWD/../../" && pwd)
+CONTEXT=$CONTEXT terraform --version
+CONTEXT=$CONTEXT terraform init
+
+# option 3
+export CONTEXT=$(cd "$PWD/../../" && pwd)
+terraform --version
+terraform init
+```
+
+#### `DOTENV_FILE` variable
+
+All variables in `DOTENV_FILE` file will be available inside the container.
+
+By default, the terraform container will use `${PWD}/.env` file.
+
+Inform a different value if you want to point to another one.
+
+```shell
+export DOTENV_FILE=local.env
+terraform init
+terraform plan
+
+# or
+DOTENV_FILE=local.env terraform init
+DOTENV_FILE=local.env terraform plan
+```
+
+#### `TF_RC_FILE` variable
+
+This is used for Terraform Cloud login.
+
+By default, the terraform container will use `${HOME}/.terraformrc` file.
+
+Inform a different value if you want to point to another one.
+
+```shell
+export TF_RC_FILE=/another/path/to/terraform-credentials/file
+terraform init
+# it should recognize the backend config pointing to your TF Cloud workspace(s)
+```
+
+#### `AWS_CREDENTIALS_FOLDER` variable
+
+This is used for AWS CLI authentication.
+
+By default, the terraform container will use `${HOME}/.aws` folder.
+
+Inform a different value if you want to point to another one.
+
+```shell
+export AWS_PROFILE=your-aws-profile
+export AWS_CREDENTIALS_FOLDER=/another/path/to/credentials/folder/
+terraform init
+terraform plan
+terraform apply
+# it should be able to deploy to your aws account based on the credentials used
+```
+
+> See [more about AWS auth configs](config/aws).
+
+#### `GCLOUD_CREDENTIALS_FOLDER` and `GOOGLE_APPLICATION_CREDENTIALS` variables
+
+This is used for GCP CLI authentication.
+
+By default, the terraform container will use `${HOME}/.config/gcloud` folder,
+and `/root/.config/gcloud/application_default_credentials.json` file, respectively.
+
+> `GOOGLE_APPLICATION_CREDENTIALS` path starts with `/root/` because this is the default user inside the container. Therefore you should not change it to your local user.
+
+Inform different values if you want to point to another one.
+
+```shell
+export GCLOUD_CREDENTIALS_FOLDER=/another/path/to/credentials/folder/
+export GOOGLE_APPLICATION_CREDENTIALS=/root/another/path/to/credentials/file
+terraform init
+terraform plan
+terraform apply
+# it should be able to deploy to your cloud account based on the credentials used
 ```
 
 ### Ookla Speedtest CLI

--- a/bin/terraform
+++ b/bin/terraform
@@ -1,20 +1,46 @@
 #!/bin/bash
 set -e
 
-IMAGE=hashicorp/terraform:1.3.9
-CONTEXTDIR=/context
-WORKDIR=${CONTEXTDIR}/app
+IMAGE=hashicorp/terraform:1.8.3
+WORKDIR=${PWD}
 
+# This folder will be mounted on the container
 if [ -z "${CONTEXT}" ]; then
     # defaults to parent folder
-    CONTEXT=$(cd "${PWD}/../" && pwd)
+    CONTEXT=$(cd "${WORKDIR}/../" && pwd)
+fi
+
+# All variables in this DOTENV_FILE will be available inside the container
+if [ -z "${DOTENV_FILE}" ]; then
+    DOTENV_FILE="${WORKDIR}/.env"
+    [[ ! -f $DOTENV_FILE ]] && touch $DOTENV_FILE
+fi
+
+# This is used for Terraform Cloud login
+if [ -z "${TF_CREDENTIALS_FILE}" ]; then
+    TF_CREDENTIALS_FILE="${HOME}/.terraformrc"
+    [[ ! -f ${TF_CREDENTIALS_FILE} ]] && touch ${TF_CREDENTIALS_FILE}
+fi
+
+# AWS CLI authentication
+if [ -z "$AWS_CREDENTIALS_FOLDER" ]; then
+    AWS_CREDENTIALS_FOLDER="$HOME/.aws"
+    mkdir -p $AWS_CREDENTIALS_FOLDER
+fi
+
+# GCP CLI authentication
+if [ -z "$GCLOUD_CREDENTIALS_FOLDER" ]; then
+    GCLOUD_CREDENTIALS_FOLDER="$HOME/.config/gcloud"
+    mkdir -p $GCLOUD_CREDENTIALS_FOLDER
+fi
+if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+    GOOGLE_APPLICATION_CREDENTIALS="/root/.config/gcloud/application_default_credentials.json"
 fi
 
 cat <<EOF
 
 ################################################################################
-Context: ${CONTEXT}
-Mounted on: ${CONTEXTDIR}
+Context mounted on: ${CONTEXT}
 Workdir: ${WORKDIR}
 ################################################################################
 
@@ -29,9 +55,12 @@ docker run -it --rm \
     --platform linux/amd64 \
     --name terraform-cli \
     --env AWS_PROFILE=${AWS_PROFILE} \
-    --volume ${HOME}/.aws:/root/.aws \
-    --volume ${HOME}/.terraformrc:/root/.terraformrc \
-    --volume ${CONTEXT}:${CONTEXTDIR} \
-    --volume ${PWD}:${WORKDIR} \
+    --env GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS \
+    --env-file $DOTENV_FILE \
+    --volume $AWS_CREDENTIALS_FOLDER:/root/.aws \
+    --volume $GCLOUD_CREDENTIALS_FOLDER:/root/.config/gcloud \
+    --volume $TF_CREDENTIALS_FILE:/root/.terraformrc \
+    --volume ${CONTEXT}:${CONTEXT} \
+    --volume ${WORKDIR}:${WORKDIR} \
     --workdir ${WORKDIR} \
     $IMAGE "${@}"

--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,7 @@ show_begin() {
 ==============================================================
   Warning: Root access may be needed.
 ==============================================================
-  GitHub: https://github.com/DavidCardso/my-ez-cli
+  GitHub: https://github.com/DavidCardoso/my-ez-cli
 ==============================================================
 
 EOF

--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,7 @@ show_begin() {
 ==============================================================
   Warning: Root access may be needed.
 ==============================================================
-  GitHub: https://github.com/My-Tooling/my-ez-cli
+  GitHub: https://github.com/DavidCardso/my-ez-cli
 ==============================================================
 
 EOF
@@ -126,8 +126,8 @@ install_yarn-berry() {
 }
 
 install_docker-compose-viz() {
-    sudo ln -sf ${BASEDIR}/bin/docker-compose-viz /usr/local/bin/docker-compose-viz
     show_msg "Activating docker-compose-viz..."
+    sudo ln -sf ${BASEDIR}/bin/docker-compose-viz /usr/local/bin/docker-compose-viz
 }
 
 install_all() {


### PR DESCRIPTION
- upgrade terraform version to 1.8.3
- update terraform section on README
- improve how aws, gcp, and TF cloud credentials are passed to the container
- add support to dotenv file
- improve how to pass a parent folder as CONTEXT to the container
    
closes #30