### PR TITLE
feat(#35): upgrades serverless framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ yarn-berry --version # it should show 3.6+
 
 ### Serverless Framework
 
-[Building the docker image](docker/serverless).
+It is ready to work with AWS.
+
+> [See more about the docker image](docker/serverless).
 
 ```shell
 # see versions

--- a/bin/serverless
+++ b/bin/serverless
@@ -1,10 +1,17 @@
 #!/bin/sh
 set -e
 
-# see "../docker/serverless/build"
-IMAGE=davidcardoso/docker-serverless-framework:latest
 WORKDIR=/app
 
+# see "../docker/serverless/" for more info.
+IMAGE=davidcardoso/serverless-framework
+
+# via env var
+if [ -z "$IMAGE_TAG" ]; then
+    IMAGE_TAG=latest
+fi
+
+# via env var
 if [ -z "${STACK_NAME}"]; then
     STACK_NAME=development
 fi
@@ -13,12 +20,12 @@ fi
 docker run -it --rm \
     --platform linux/amd64 \
     --name serverless-cli \
-    --env AWS_PROFILE=$AWS_PROFILE \
+    --env AWS_PROFILE=${AWS_PROFILE} \
     --env AWS_SDK_LOAD_CONFIG=1 \
     --env STACK_NAME=${STACK_NAME} \
-    --volume $HOME/.aws:/root/.aws \
-    --volume $PWD:$WORKDIR \
-    --workdir $WORKDIR \
+    --volume ${HOME}/.aws:/root/.aws \
+    --volume ${PWD}:${WORKDIR} \
+    --workdir ${WORKDIR} \
     --entrypoint serverless \
     --network="host" \
-    $IMAGE "${@}"
+    ${IMAGE}:${IMAGE_TAG} "${@}"

--- a/bin/serverless
+++ b/bin/serverless
@@ -23,6 +23,7 @@ docker run -it --rm \
     --env AWS_PROFILE=${AWS_PROFILE} \
     --env AWS_SDK_LOAD_CONFIG=1 \
     --env STACK_NAME=${STACK_NAME} \
+    --env SLS_DEBUG=${SLS_DEBUG} \
     --volume ${HOME}/.aws:/root/.aws \
     --volume ${PWD}:${WORKDIR} \
     --workdir ${WORKDIR} \

--- a/docker/serverless/Dockerfile
+++ b/docker/serverless/Dockerfile
@@ -1,9 +1,9 @@
 FROM amazonlinux:latest
 
-LABEL Author: David Cardoso <dev@davidcardoso.me>
+LABEL Author: David Cardoso <dev+github@davidcardoso.me>
 
-ENV NODE_VERSION=16
-ENV SERVERLESS_VERSION=2.72.2
+ENV NODE_VERSION=20
+ENV SERVERLESS_VERSION=3.38.0
 
 # include aws exec in the PATH env var
 ENV PATH=$PATH:/root/.local/bin/
@@ -12,7 +12,6 @@ ENV PATH=$PATH:/root/.local/bin/
 RUN yum install -y python-pip groff zip unzip jq bc &&\
     pip install --user awscli &&\
     # Add NodeJS + Yarn
-    yum install -y curl &&\
     curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - &&\
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo &&\
     yum install -y yarn &&\

--- a/docker/serverless/Dockerfile
+++ b/docker/serverless/Dockerfile
@@ -15,6 +15,8 @@ RUN yum install -y python-pip groff zip unzip jq bc &&\
     curl -sL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - &&\
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo &&\
     yum install -y yarn &&\
+    # Add Java
+    yum install -y java &&\
     # Add Serverless Framework
     yarn global add serverless@${SERVERLESS_VERSION}
 

--- a/docker/serverless/README.md
+++ b/docker/serverless/README.md
@@ -1,10 +1,10 @@
 # Serverless Framework via Docker
 
-The docker image is based on Amazon Linux Machine and contains AWS CLI, Python, Node, Yarn, and Serverless Framework.
+The docker image is based on Amazon Linux Machine and contains AWS CLI, Python, Node, Yarn, Java, and Serverless Framework.
 
 ## Building the image
 
 1. Change the `NODE_VERSION` and `SERVERLESS_VERSION` environment variables in the `Dockerfile` file if necessary.
 2. Run the `./build` script (defaults to `IMAGE_TAG=latest`).
 
-> To build another image tag, try this: `IMAGE_TAG=3.38.0 ./build`
+> To build another image tag, try this: `IMAGE_TAG=1.2.3 ./build`

--- a/docker/serverless/README.md
+++ b/docker/serverless/README.md
@@ -1,7 +1,10 @@
-Serverless Framework via Docker
---
+# Serverless Framework via Docker
 
-# Building the image
+The docker image is based on Amazon Linux Machine and contains AWS CLI, Python, Node, Yarn, and Serverless Framework.
 
-1. Set `NODE_VERSION` and `SERVERLESS_VERSION` env vars in the `Dockerfile` file if needed.
-1. Run the `./build` script.
+## Building the image
+
+1. Change the `NODE_VERSION` and `SERVERLESS_VERSION` environment variables in the `Dockerfile` file if necessary.
+2. Run the `./build` script (defaults to `IMAGE_TAG=latest`).
+
+> To build another image tag, try this: `IMAGE_TAG=3.38.0 ./build`

--- a/docker/serverless/build
+++ b/docker/serverless/build
@@ -1,12 +1,17 @@
 #!/bin/sh
 set -e
 
-IMAGE=davidcardoso/docker-serverless-framework:latest
+IMAGE=davidcardoso/serverless-framework
+
+# Via env var
+if [ -z "$IMAGE_TAG" ]; then
+    IMAGE_TAG=latest
+fi
 
 echo "=========================================================="
-echo "Building '${IMAGE}'..."
+echo "Building '${IMAGE}:${IMAGE_TAG}'..."
 echo "=========================================================="
 
 docker build \
     --platform linux/amd64 \
-    --tag ${IMAGE} .
+    --tag ${IMAGE}:${IMAGE_TAG} .

--- a/setup.sh
+++ b/setup.sh
@@ -99,8 +99,8 @@ install_yarn() {
 }
 
 install_serverless() {
-    sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/serverless
     show_msg "Activating serverless..."
+    sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/serverless
 }
 
 install_terraform() {

--- a/setup.sh
+++ b/setup.sh
@@ -101,6 +101,8 @@ install_yarn() {
 install_serverless() {
     show_msg "Activating serverless..."
     sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/serverless
+    sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/sls
+    show_msg "> You can use 'serverless' or just 'sls' alias."
 }
 
 install_terraform() {


### PR DESCRIPTION
- upgrades serverless framework to v3.38.0
- upgrades Node engine to v20 LTS
- improves how `bin/serverless` script choose the docker image tag to be run
- improves the `docker/serverless/build` script to be able to build other tags besides the `latest`
- improves Dockerfile instructions
- update READMEs

closes #35