### PR TITLE
feat: add support to npx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # IDEs
 .vscode/
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Tools via **Unix Command Line Interface** with no installation and just using **
       - [Using other Python versions](#using-other-python-versions)
     - [NodeJS](#nodejs)
       - [Using other NodeJS versions](#using-other-nodejs-versions)
-      - [Using NodeJS, NPM, and Yarn with custom ports](#using-nodejs-npm-and-yarn-with-custom-ports)
+      - [Using NodeJS, npm, npx, and yarn with custom ports](#using-nodejs-npm-npx-and-yarn-with-custom-ports)
       - [Using NPM and Yarn with NPM token](#using-npm-and-yarn-with-npm-token)
     - [NPM](#npm)
       - [Using NPM with other NodeJS versions](#using-npm-with-other-nodejs-versions)
+    - [NPX](#npx)
     - [Yarn](#yarn)
       - [Using Yarn with other NodeJS versions](#using-yarn-with-other-nodejs-versions)
       - [Yarn Berry (v2+)](#yarn-berry-v2)
@@ -182,13 +183,14 @@ node22 -v
 node24 -v
 ```
 
-#### Using NodeJS, NPM, and Yarn with custom ports
+#### Using NodeJS, npm, npx, and yarn with custom ports
 
 Use `MEC_BIND_PORTS` env var if you want to bind ports between the host and container:
 
 ```shell
 MEC_BIND_PORTS="8080:80 9090:80" node
 MEC_BIND_PORTS="8080:80 9090:80" npm
+MEC_BIND_PORTS="8080:80 9090:80" npx
 MEC_BIND_PORTS="8080:80 9090:80" yarn
 
 # or
@@ -257,6 +259,27 @@ npm16 -v
 npm18 -v
 npm20 -v
 npm22 -v
+```
+
+### NPX
+
+> It is using NodeJS 22 as default.
+
+```shell
+# exec a standalone package
+npx cowsay "Hello!"
+# Need to install the following packages:
+# cowsay@1.6.0
+# Ok to proceed? (y) y
+
+#  _______
+# < Hello >
+#  -------
+#         \   ^__^
+#          \  (oo)\_______
+#             (__)\       )\/\
+#                 ||----w |
+#                 ||     ||
 ```
 
 ### Yarn

--- a/bin/npx
+++ b/bin/npx
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+# default image
+IMAGE=${IMAGE:-"node:22-alpine"}
+WORKDIR=/app
+
+# Check README for usage info.
+
+if [ ! -z "$MEC_BIND_PORTS" ]; then
+    for PORT in $MEC_BIND_PORTS; do
+        PORTS="$PORTS -p $PORT"
+    done
+fi
+
+# should be executed from your working directory
+docker run -it --rm \
+    --env NPM_TOKEN=$NPM_TOKEN \
+    --volume $HOME/.npmrc:/root/.npmrc \
+    --volume $PWD:$WORKDIR \
+    --workdir $WORKDIR \
+    $PORTS \
+    --entrypoint npx \
+    $IMAGE "${@}"

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,7 @@ Type the number of the OPTION:
 # terraform: Terraform CLI
 # gcloud: Google Cloud CLI
 # node: NodeJS 14, 16, 18, 20, 22 (default), and 24
+# npx: npx over NodeJS 22
 # npm: NPM over NodeJS 14, 16, 18, 20, and 22 (default)
 # yarn: Yarn over NodeJS 14, 16, 18, 20, and 22 (default)
 # yarn-berry: Yarn Berry (v2+) over NodeJS 18
@@ -113,6 +114,12 @@ install_npm() {
     sudo ln -sf ${BASEDIR}/bin/npm20 /usr/local/bin/npm20
 }
 
+install_npx() {
+    show_msg "Activating npx (over NodeJS v22)..."
+    sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx
+    sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx22
+}
+
 install_yarn() {
     show_msg "Activating yarn (using NodeJS v22)..."
     sudo ln -sf ${BASEDIR}/bin/yarn /usr/local/bin/yarn
@@ -196,6 +203,7 @@ install_all() {
     install_aws
     install_node
     install_npm
+    install_npx
     install_yarn
     install_yarn-berry
     install_serverless
@@ -213,7 +221,7 @@ install_all() {
 show_begin
 
 PS3="Choose an option: "
-select opt in ALL aws terraform cdktf gcloud node npm yarn yarn-berry serverless speedtest docker-compose-viz playwright python EXIT; do
+select opt in ALL aws terraform cdktf gcloud node npm npx yarn yarn-berry serverless speedtest docker-compose-viz playwright python EXIT; do
     case ${opt} in
     ALL) install_all ;;
     aws) install_aws ;;
@@ -222,6 +230,7 @@ select opt in ALL aws terraform cdktf gcloud node npm yarn yarn-berry serverless
     gcloud) install_gcloud ;;
     node) install_node ;;
     npm) install_npm ;;
+    npx) install_npx ;;
     yarn) install_yarn ;;
     yarn-berry) install_yarn-berry ;;
     serverless) install_serverless ;;
@@ -238,10 +247,9 @@ done
 
 # TODO: add 'uninstall' option
 
-show_msg "> If you want to check and/or adapt how each script is being executed,\
-just check them inside '${BASEDIR}/bin/' folder."
+show_msg "> Check the scripts in '${BASEDIR}/bin/' folder."
 
-show_msg "> For more info, check the README."
+show_msg "> Check the '${BASEDIR}/README.md' file."
 
 # End
 


### PR DESCRIPTION
`npx` can already be used from within the `node` docker image used by `node`, `npm`, and `yarn` .
So if you run some standalone package like `yarn projen` (from `package.json` - `scripts` object), the `yarn` container will automatically call the `npx` from within its container.

However, if you want to call `npx` directly, you do need this new dedicated `npx` script.

Closes #49
