### PR TITLE
feat: add mec doctor health check subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ See [Web Dashboard](#web-dashboard----mec-dashboard) for page reference.
 ### Health Check — `mec doctor`
 
 ```shell
-mec doctor               # Check Docker, tools, AI, dashboard, and data directory health
+mec doctor               # Check Docker, Zsh, tools, AI, dashboard, and data directory health
 ```
 
 Prints a structured report with ✓ pass / ⚠ warn / ✗ fail per check and a summary. Exits `1` if any check fails — scriptable.

--- a/bin/mec
+++ b/bin/mec
@@ -53,6 +53,7 @@ Commands:
   config              Manage configuration
   ai                  AI analysis (Claude Code)
   dashboard           Log and AI analysis web UI (start|stop|status|open)
+  doctor              Health check (Docker, Zsh, tools, AI, dashboard, data dir)
   logs                Log management
   claude              Run Claude Code
   claude firewall     Manage Claude Code container firewall
@@ -1184,6 +1185,199 @@ EOF
 }
 
 # ----------------------------------------------------------------------------
+# Doctor Commands
+# ----------------------------------------------------------------------------
+
+mec_doctor() {
+    local subcmd="${1:-}"
+    shift 2>/dev/null || true
+
+    case "$subcmd" in
+        help|--help|-h)
+            cat <<'EOF'
+Usage: mec doctor
+
+Run health checks on Docker, Zsh, tools, AI integration, dashboard, and data directory.
+
+Prints a structured report with ✓ pass / ⚠ warn / ✗ fail per check.
+Exits 1 if any check fails — scriptable.
+
+Examples:
+  mec doctor
+  mec doctor && echo "all good"
+EOF
+            return 0
+            ;;
+        ""|run)
+            _mec_doctor_run
+            return $?
+            ;;
+        *)
+            echo "Unknown doctor command: $subcmd" >&2
+            echo "Run 'mec doctor help' for usage" >&2
+            return 1
+            ;;
+    esac
+}
+
+_mec_doctor_run() {
+    local failures=0
+    local warnings=0
+
+    _doc_pass() { echo "  ✓  $*"; }
+    _doc_warn() { echo "  ⚠  $*"; warnings=$((warnings + 1)); }
+    _doc_fail() { echo "  ✗  $*"; failures=$((failures + 1)); }
+
+    # ------------------------------------------------------------------
+    # 1. Docker
+    # ------------------------------------------------------------------
+    if ! command -v docker >/dev/null 2>&1; then
+        _doc_fail "Docker: not installed or not in PATH"
+    elif ! docker info >/dev/null 2>&1; then
+        _doc_fail "Docker daemon: not running  (start Docker Desktop or dockerd)"
+    else
+        local docker_version
+        docker_version=$(docker --version 2>/dev/null | sed 's/Docker version //' | cut -d',' -f1)
+        _doc_pass "Docker daemon running  (${docker_version})"
+    fi
+
+    # ------------------------------------------------------------------
+    # 2. Zsh
+    # ------------------------------------------------------------------
+    if ! command -v zsh >/dev/null 2>&1; then
+        _doc_fail "Zsh: not installed  (required — install via Homebrew: brew install zsh)"
+    else
+        local zsh_version
+        zsh_version=$(zsh --version 2>/dev/null | awk '{print $2}')
+        _doc_pass "Zsh: installed  (${zsh_version})"
+    fi
+
+    # Oh My Zsh
+    if [ -d "${HOME}/.oh-my-zsh" ]; then
+        _doc_pass "Oh My Zsh: installed  (~/.oh-my-zsh)"
+    else
+        _doc_warn "Oh My Zsh: not found  (recommended — https://ohmyz.sh)"
+    fi
+
+    # ------------------------------------------------------------------
+    # 3. Data directory
+    # ------------------------------------------------------------------
+    local data_dir="${MEC_DATA_DIR:-${HOME}/.my-ez-cli}"
+    if [ ! -d "$data_dir" ]; then
+        _doc_fail "Data directory: not found  (${data_dir} — run 'mec logs enable' to create)"
+    elif [ ! -w "$data_dir" ]; then
+        _doc_fail "Data directory: not writable  (${data_dir})"
+    else
+        _doc_pass "Data directory: ${data_dir}  (exists, writable)"
+    fi
+
+    # ------------------------------------------------------------------
+    # 4. Config file
+    # ------------------------------------------------------------------
+    local config_file="${CONFIG_FILE:-${HOME}/.my-ez-cli/config.yaml}"
+    if [ -f "$config_file" ]; then
+        _doc_pass "Config file: ${config_file}  (exists)"
+    else
+        _doc_warn "Config file: not found  (defaults will be used — run 'mec config reset' to create)"
+    fi
+
+    # ------------------------------------------------------------------
+    # 5. Logging
+    # ------------------------------------------------------------------
+    local logs_enabled
+    logs_enabled=$(config_get_default "logs.enabled" "false")
+    if [ "$logs_enabled" = "true" ]; then
+        _doc_pass "Logs: enabled"
+    else
+        _doc_warn "Logs: disabled  (run 'mec logs enable' to persist sessions)"
+    fi
+
+    # ------------------------------------------------------------------
+    # 6. AI — enabled state (informational, no failure)
+    # ------------------------------------------------------------------
+    local ai_enabled
+    ai_enabled=$(config_get_default "ai.enabled" "false")
+    if [ "$ai_enabled" = "true" ]; then
+        _doc_pass "AI: enabled"
+    else
+        _doc_warn "AI: disabled  (run 'mec ai enable' to activate)"
+    fi
+
+    # ------------------------------------------------------------------
+    # 7. AI — middleware image
+    # ------------------------------------------------------------------
+    if docker image inspect "$MEC_IMAGE_AI_SERVICE" >/dev/null 2>&1; then
+        _doc_pass "AI middleware image: available  (${MEC_IMAGE_AI_SERVICE})"
+    else
+        _doc_fail "AI middleware image: not found  (docker pull ${MEC_IMAGE_AI_SERVICE})"
+    fi
+
+    # ------------------------------------------------------------------
+    # 8. AI — Claude Code image
+    # ------------------------------------------------------------------
+    if docker image inspect "$MEC_IMAGE_CLAUDE" >/dev/null 2>&1; then
+        _doc_pass "Claude Code image: available  (${MEC_IMAGE_CLAUDE})"
+    else
+        _doc_fail "Claude Code image: not found  (docker pull ${MEC_IMAGE_CLAUDE})"
+    fi
+
+    # ------------------------------------------------------------------
+    # 9. AI — auth
+    # ------------------------------------------------------------------
+    if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+        _doc_pass "AI auth: ANTHROPIC_API_KEY set"
+    elif [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+        _doc_pass "AI auth: CLAUDE_CODE_OAUTH_TOKEN set"
+    elif [ -f "${HOME}/.claude/.credentials.json" ]; then
+        _doc_warn "AI auth: ~/.claude/ found  (interactive use only — set ANTHROPIC_API_KEY for automated analysis)"
+    else
+        _doc_warn "AI auth: not configured  (set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN)"
+    fi
+
+    # ------------------------------------------------------------------
+    # 10. Dashboard image
+    # ------------------------------------------------------------------
+    if docker image inspect "$MEC_IMAGE_DASHBOARD" >/dev/null 2>&1; then
+        _doc_pass "Dashboard image: available  (${MEC_IMAGE_DASHBOARD})"
+    else
+        _doc_warn "Dashboard image: not found  (docker pull ${MEC_IMAGE_DASHBOARD})"
+    fi
+
+    # ------------------------------------------------------------------
+    # 11. Dashboard running
+    # ------------------------------------------------------------------
+    local dashboard_port
+    dashboard_port=$(config_get_default "ai.dashboard.port" "4242" 2>/dev/null || echo "4242")
+    if docker inspect "$MEC_DASHBOARD_CONTAINER" >/dev/null 2>&1; then
+        local dash_state
+        dash_state=$(docker inspect --format '{{.State.Status}}' "$MEC_DASHBOARD_CONTAINER" 2>/dev/null)
+        if [ "$dash_state" = "running" ]; then
+            _doc_pass "Dashboard: running  (http://localhost:${dashboard_port})"
+        else
+            _doc_warn "Dashboard: ${dash_state}  (run 'mec dashboard start')"
+        fi
+    else
+        _doc_warn "Dashboard: not running  (run 'mec dashboard start')"
+    fi
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    echo ""
+    if [ "$failures" -gt 0 ] && [ "$warnings" -gt 0 ]; then
+        echo "doctor: ${failures} failure(s), ${warnings} warning(s)"
+    elif [ "$failures" -gt 0 ]; then
+        echo "doctor: ${failures} failure(s)"
+    elif [ "$warnings" -gt 0 ]; then
+        echo "doctor: ${warnings} warning(s)  (no failures)"
+    else
+        echo "doctor: all checks passed"
+    fi
+
+    [ "$failures" -eq 0 ]
+}
+
+# ----------------------------------------------------------------------------
 # Main Dispatch
 # ----------------------------------------------------------------------------
 
@@ -1227,6 +1421,10 @@ case "$COMMAND" in
     dashboard)
         shift
         mec_dashboard "${1:-help}" "${@:2}"
+        ;;
+    doctor)
+        shift
+        mec_doctor "${@}"
         ;;
     version|--version|-v)
         show_version

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # My Ez CLI - v1.0.0 Roadmap
 
-**Status:** Phase 3 Complete — Phase 3.4 In Progress - v1.0.0 Release Candidate
+**Status:** Phase 3.4 Complete - v1.0.0 Release Candidate
 **Target:** First Stable Release (v1.0.0)
 **Previous Versions:** 0.x.y (beta releases)
 **Phase 1 Completed:** 2026-01-20
@@ -395,6 +395,24 @@ mec ai status
 
 ---
 
+### Phase 3.4: mec doctor ✅
+
+**Status:** Complete
+**Priority:** P1
+**Completed:** 2026-03-26
+**Goal:** Health-check subcommand for Docker, Zsh, AI, dashboard, data directory, and auth
+
+- ✅ `mec doctor` prints ✓/⚠/✗ per check with summary line
+- ✅ Exits 1 if any check fails (scriptable: `mec doctor && deploy`)
+- ✅ Checks: Docker daemon, Zsh + Oh My Zsh, data dir, config file, logs, AI enabled/images/auth, dashboard image/running
+- ✅ Unit tests in `tests/unit/test-doctor.bats` (14 tests)
+
+**Deliverables:**
+- Single `mec doctor` command for full environment health check
+- Structured pass/warn/fail output with actionable hints
+
+---
+
 ## Future Ideas
 
 Items below are not scheduled — they may become implementation phases once v1.0.0 is stable.
@@ -444,7 +462,7 @@ Items below are not scheduled — they may become implementation phases once v1.
 | Dashboard daemon | 3.2 | P0 | High | High | ✅ Complete |
 | Dashboard Web UI | 3.2 | P0 | High | High | ✅ Complete |
 | Shell completion | Future | P1 | Medium | Low | 💡 Future |
-| `mec doctor` | Future | P1 | High | Medium | 💡 Future |
+| `mec doctor` | 3.4 | P1 | High | Medium | ✅ Complete |
 | Homebrew formula | Future | P1 | Medium | Medium | 💡 Future |
 | PostgreSQL logs | Future | P2 | Low | Medium | 💡 Future |
 | Log encryption | Future | P2 | Medium | Medium | 💡 Future |

--- a/tests/unit/test-doctor.bats
+++ b/tests/unit/test-doctor.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# ============================================================================
+# Tests for mec doctor subcommand
+# ============================================================================
+
+BASEDIR="$(cd "$(dirname "$BATS_TEST_DIRNAME")/.." && pwd)"
+
+setup() {
+    export MEC_BASE_DIR="$BASEDIR"
+
+    # Temporary config dir so tests don't touch ~/.my-ez-cli
+    TEST_CONFIG_DIR=$(mktemp -d)
+    export CONFIG_DIR="$TEST_CONFIG_DIR"
+    export CONFIG_FILE="$TEST_CONFIG_DIR/config.yaml"
+    export DEFAULT_CONFIG="$BASEDIR/config/config.default.yaml"
+
+    # Temporary data dir
+    TEST_DATA_DIR=$(mktemp -d)
+    export MEC_DATA_DIR="$TEST_DATA_DIR"
+    export MEC_LOG_DIR="$TEST_DATA_DIR/logs"
+}
+
+teardown() {
+    [ -n "$TEST_CONFIG_DIR" ] && rm -rf "$TEST_CONFIG_DIR"
+    [ -n "$TEST_DATA_DIR" ] && rm -rf "$TEST_DATA_DIR"
+}
+
+# ============================================================================
+# mec doctor help
+# ============================================================================
+
+@test "bin/mec has mec_doctor function" {
+    grep -q 'mec_doctor' "$BASEDIR/bin/mec"
+}
+
+@test "mec doctor --help prints usage" {
+    run "$BASEDIR/bin/mec" doctor --help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage: mec doctor" ]]
+}
+
+@test "mec doctor help prints usage" {
+    run "$BASEDIR/bin/mec" doctor help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage: mec doctor" ]]
+}
+
+# ============================================================================
+# mec doctor (no subcommand = run checks)
+# ============================================================================
+
+@test "mec doctor runs without arguments" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [ "$status" -eq 0 ] || [ "$status" -eq 1 ]
+}
+
+@test "mec doctor output contains check symbols" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [[ "$output" =~ "✓" ]] || [[ "$output" =~ "⚠" ]] || [[ "$output" =~ "✗" ]]
+}
+
+@test "mec doctor output contains Docker check" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [[ "$output" =~ "Docker" ]]
+}
+
+@test "mec doctor output contains Zsh check" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [[ "$output" =~ "Zsh" ]]
+}
+
+@test "mec doctor output contains Oh My Zsh check" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [[ "$output" =~ "Oh My Zsh" ]]
+}
+
+@test "mec doctor output contains data directory check" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [[ "$output" =~ "Data directory" ]]
+}
+
+@test "mec doctor output contains AI check" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [[ "$output" =~ "AI" ]]
+}
+
+@test "mec doctor output contains Dashboard check" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [[ "$output" =~ "Dashboard" ]]
+}
+
+@test "mec doctor output ends with summary line" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    run "$BASEDIR/bin/mec" doctor
+    [[ "$output" =~ "doctor:" ]]
+}
+
+@test "mec doctor exits 0 or 1 with pre-created data dir" {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+    mkdir -p "$MEC_DATA_DIR"
+    mkdir -p "$TEST_CONFIG_DIR"
+    cp "$BASEDIR/config/config.default.yaml" "$CONFIG_FILE"
+    run "$BASEDIR/bin/mec" doctor
+    [ "$status" -eq 0 ] || [ "$status" -eq 1 ]
+}
+
+@test "mec doctor unknown subcommand returns error" {
+    run "$BASEDIR/bin/mec" doctor xyz
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Unknown" ]]
+}


### PR DESCRIPTION
## Summary

- Adds `mec doctor` — a structured health-check command that audits the full environment and prints ✓/⚠/✗ per check with a summary line
- Exits `1` if any check fails, making it scriptable (`mec doctor && deploy`)
- Checks performed: Docker daemon, Zsh + Oh My Zsh, data directory, config file, logging, AI (enabled/images/auth), dashboard (image/running)
- 14 unit tests in `tests/unit/test-doctor.bats`

## Test plan

- [x] `mec doctor` — full run, verify all checks print and summary is correct
- [x] `mec doctor help` / `mec doctor --help` — usage text, exit 0
- [x] `mec doctor && echo ok` — exits 0 when no failures
- [x] `mec doctor foo` — unknown subcommand, exit 1
- [x] `bats tests/unit/test-doctor.bats` — 14/14 pass
- [x] `bats tests/unit/*.bats` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)