### PR TITLE
fix: session count/tool filter accuracy; fix ANSI escape sequences in JSON logs

### DIFF
--- a/bin/utils/log-manager.sh
+++ b/bin/utils/log-manager.sh
@@ -216,8 +216,14 @@ get_log_environment() {
 # Escape string for JSON
 escape_json() {
     STRING="$1"
-    # Basic escaping for JSON
-    printf '%s' "$STRING" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' | tr -d '\n\r' | sed 's/\\n$//'
+    # Strip ANSI/terminal escape sequences (e.g. \x1b[1G\x1b[0K cursor controls, colour codes)
+    # then escape backslashes and double-quotes, collapse newlines to \n
+    printf '%s' "$STRING" \
+        | sed 's/\x1b\[[0-9;]*[A-Za-z]//g; s/\x1b[()]//g' \
+        | tr -d '\000-\010\013\014\016-\037\177' \
+        | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' \
+        | tr -d '\n\r' \
+        | sed 's/\\n$//'
 }
 
 # Redact sensitive data from string

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -418,7 +418,6 @@ mec ai status
 Items below are not scheduled — they may become implementation phases once v1.0.0 is stable.
 
 - Shell completion (`mec` CLI, zsh/bash)
-- `mec doctor` — health checks (Docker, tools, auth, disk)
 - `mec help <tool>` — tool-specific help with examples
 - Homebrew formula (`brew install my-ez-cli`)
 - Claude Code MCP server for my-ez-cli tools
@@ -426,6 +425,7 @@ Items below are not scheduled — they may become implementation phases once v1.
 - PostgreSQL log storage (opt-in)
 - Full configuration editor UI
 - Log encryption (AES-256-GCM, opt-in)
+- Custom image local fallback — when a custom Docker image pull fails (e.g. speedtest, serverless), fall back to locally-built image if available rather than failing with "image not found"
 - Prompt injection hardening — tool output passed to Claude as inline prompt content could contain adversarial instructions; sanitization beyond control-char stripping (e.g. delimiters, input validation, output sandboxing)
 - CVE / security advisory scanning — cross-reference tool execution logs and AI analysis results against known CVE databases (NVD, OSV, GitHub Advisory) and security issue DBs; flag vulnerable package versions, deprecated images, or insecure patterns detected at runtime (needs proper planning: data sources, update cadence, false-positive rate, opt-in UX)
 - Elasticsearch + Kibana integration

--- a/services/dashboard/frontend/src/composables/useSessions.js
+++ b/services/dashboard/frontend/src/composables/useSessions.js
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue'
 
 const sessions = ref([])
+const totalSessions = ref(0)
 const loading = ref(false)
 const error = ref(null)
 
@@ -15,7 +16,9 @@ async function fetchSessions({ limit = 50 } = {}) {
   try {
     const res = await fetch(`/api/sessions?limit=${limit}`)
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    sessions.value = await res.json()
+    const data = await res.json()
+    sessions.value = data.sessions ?? data
+    totalSessions.value = data.total ?? sessions.value.length
   } catch (e) {
     error.value = e.message
   } finally {
@@ -65,5 +68,5 @@ export function useSessions() {
     })
   }
 
-  return { sessions, loading, error, fetchSessions, makeFiltered }
+  return { sessions, totalSessions, loading, error, fetchSessions, makeFiltered }
 }

--- a/services/dashboard/frontend/src/composables/useSessions.test.js
+++ b/services/dashboard/frontend/src/composables/useSessions.test.js
@@ -10,7 +10,7 @@ const mockSessions = [
 beforeEach(() => {
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve(mockSessions),
+    json: () => Promise.resolve({ sessions: mockSessions, total: mockSessions.length }),
   }))
 })
 

--- a/services/dashboard/frontend/src/pages/SessionsPage.vue
+++ b/services/dashboard/frontend/src/pages/SessionsPage.vue
@@ -4,7 +4,10 @@
       <div class="page-header-content">
         <div class="page-header-left">
           <h1 class="page-title">Sessions</h1>
-          <span v-if="!loading" class="session-count">{{ filteredSessions.length }} session{{ filteredSessions.length !== 1 ? 's' : '' }}</span>
+          <span v-if="!loading" class="session-count">
+            {{ filteredSessions.length }} session{{ filteredSessions.length !== 1 ? 's' : '' }}
+            <template v-if="totalSessions > sessions.length"> of {{ totalSessions }} total</template>
+          </span>
         </div>
       </div>
     </div>
@@ -80,13 +83,14 @@ import { useSessions } from '../composables/useSessions.js'
 import { useWebSocket } from '../composables/useWebSocket.js'
 
 const router = useRouter()
-const { sessions, loading, fetchSessions, makeFiltered } = useSessions()
+const { sessions, totalSessions, loading, fetchSessions, makeFiltered } = useSessions()
 const { onRefresh } = useWebSocket()
 
 const search = ref('')
 const selectedTools = ref([])
 const selectedAiStatus = ref('all')
 const selectedExitCode = ref('all')
+const allToolNames = ref([])
 
 const aiStatusOptions = [
   { label: 'All AI statuses', value: 'all' },
@@ -101,7 +105,9 @@ const exitCodeOptions = [
   { label: 'Failure (≠0)', value: 'failure' },
 ]
 
+// Use the full tool list from stats (covers all tools ever used, not just the fetched window)
 const availableTools = computed(() => {
+  if (allToolNames.value.length > 0) return allToolNames.value
   const tools = new Set(sessions.value.map((s) => s.tool).filter(Boolean))
   return [...tools].sort()
 })
@@ -126,8 +132,16 @@ function clearFilters() {
   selectedExitCode.value = 'all'
 }
 
-onMounted(() => {
+onMounted(async () => {
   fetchSessions({ limit: 100 })
+  // Fetch stats to get the full list of tools (not limited by the sessions fetch window)
+  try {
+    const res = await fetch('/api/stats')
+    if (res.ok) {
+      const stats = await res.json()
+      allToolNames.value = Object.keys(stats.sessions_by_tool || {}).sort()
+    }
+  } catch (_) { /* fallback to session-derived list */ }
   const cleanup = onRefresh(() => fetchSessions({ limit: 100 }))
   onUnmounted(cleanup)
 })

--- a/services/dashboard/src/api/sessions.py
+++ b/services/dashboard/src/api/sessions.py
@@ -17,9 +17,11 @@ def _data_root(request: Request) -> Path:
 
 
 @router.get("")
-def sessions_list(request: Request, limit: int = 50) -> list[dict[str, object]]:
-    """Return up to `limit` sessions, newest-first."""
-    return [asdict(s) for s in list_sessions(_data_root(request), limit=limit)]
+def sessions_list(request: Request, limit: int = 50) -> dict[str, object]:
+    """Return up to `limit` sessions newest-first, plus the total count."""
+    result = list_sessions(_data_root(request), limit=limit)
+    sessions = result["sessions"]  # type: ignore[index]
+    return {"sessions": [asdict(s) for s in sessions], "total": result["total"]}  # type: ignore[arg-type]
 
 
 @router.get("/{session_id}")

--- a/services/dashboard/src/sessions.py
+++ b/services/dashboard/src/sessions.py
@@ -212,12 +212,25 @@ class SessionDetail(SessionSummary):
 
 
 def _read_json(path: Path) -> dict[str, object]:
-    """Read and parse a JSON file; return empty dict on any error."""
+    """Read and parse a JSON file; return empty dict on any error.
+
+    If the file contains raw ANSI/control characters that make it invalid JSON,
+    strip them and retry once — this recovers sessions logged before escape_json
+    was hardened to strip terminal control sequences.
+    """
+    import re
+
     try:
         content = path.read_text().strip()
         if not content:
             return {}
-        return json.loads(content)  # type: ignore[no-any-return]
+        try:
+            return json.loads(content)  # type: ignore[no-any-return]
+        except json.JSONDecodeError:
+            # Strip ANSI escape sequences and C0 control characters, then retry
+            clean = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", content)
+            clean = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", clean)
+            return json.loads(clean)  # type: ignore[no-any-return]
     except (OSError, json.JSONDecodeError) as exc:
         logger.debug("Could not read %s: %s", path, exc)
         return {}
@@ -261,12 +274,17 @@ def _sidecar_path(log_path: Path, data_root: Path) -> Path:
         return log_path  # fallback (should not happen)
 
 
-def list_sessions(data_root: Path, limit: int = 50) -> list[SessionSummary]:
-    """Return up to `limit` sessions, newest-first."""
+def list_sessions(data_root: Path, limit: int = 50) -> dict[str, object]:
+    """Return up to `limit` sessions newest-first, plus the total count of valid sessions."""
+    all_files = _log_files(data_root)
     results: list[SessionSummary] = []
-    for log_path in _log_files(data_root)[:limit]:
+    total = 0
+    for log_path in all_files:
         data = _read_json(log_path)
         if not data:
+            continue
+        total += 1
+        if len(results) >= limit:
             continue
         execution: dict[str, object] = data.get("execution", {})  # type: ignore[assignment]
         exit_code_raw = execution.get("exit_code")
@@ -282,7 +300,7 @@ def list_sessions(data_root: Path, limit: int = 50) -> list[SessionSummary]:
                 ai_status=status,
             )
         )
-    return results
+    return {"sessions": results, "total": total}
 
 
 def get_session(data_root: Path, session_id: str) -> SessionDetail | None:

--- a/services/dashboard/tests/test_sessions.py
+++ b/services/dashboard/tests/test_sessions.py
@@ -54,56 +54,83 @@ class TestListSessions:
     """Tests for list_sessions()."""
 
     def test_empty_data_root_returns_empty(self, data_root: Path) -> None:
-        assert list_sessions(data_root) == []
+        result = list_sessions(data_root)
+        assert result["sessions"] == []
+        assert result["total"] == 0
 
     def test_returns_session_summary(self, data_root: Path) -> None:
         _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-1")
-        sessions = list_sessions(data_root)
+        result = list_sessions(data_root)
+        sessions = result["sessions"]
         assert len(sessions) == 1
         assert isinstance(sessions[0], SessionSummary)
         assert sessions[0].session_id == "mec-npm-1"
         assert sessions[0].tool == "npm"
         assert sessions[0].exit_code == 0
 
+    def test_total_reflects_valid_sessions_not_raw_files(self, data_root: Path) -> None:
+        for i in range(5):
+            _write_log(data_root, "npm", f"2026-03-25_1{i}-00-00", f"mec-npm-{i}")
+        # Add an empty (invalid) JSON file — should NOT be counted in total
+        empty = data_root / "logs" / "npm" / "2026-03-25_19-00-00.json"
+        empty.write_text("")
+        result = list_sessions(data_root, limit=3)
+        assert result["total"] == 5  # 5 valid, 1 empty skipped
+        assert len(result["sessions"]) == 3
+
     def test_ai_status_none_when_no_sidecar(self, data_root: Path) -> None:
         _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-1")
-        assert list_sessions(data_root)[0].ai_status == "none"
+        assert list_sessions(data_root)["sessions"][0].ai_status == "none"
 
     def test_ai_status_pending_when_sidecar_empty(self, data_root: Path) -> None:
         _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-1")
         _write_sidecar(data_root, "npm", "2026-03-25_12-00-00", result="")
-        assert list_sessions(data_root)[0].ai_status == "pending"
+        assert list_sessions(data_root)["sessions"][0].ai_status == "pending"
 
     def test_ai_status_done_when_result_present(self, data_root: Path) -> None:
         _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-1")
         _write_sidecar(data_root, "npm", "2026-03-25_12-00-00", result="All good.")
-        assert list_sessions(data_root)[0].ai_status == "done"
+        assert list_sessions(data_root)["sessions"][0].ai_status == "done"
 
     def test_sorted_newest_first(self, data_root: Path) -> None:
         _write_log(data_root, "npm", "2026-03-25_10-00-00", "mec-npm-old")
         _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-new")
-        sessions = list_sessions(data_root)
+        sessions = list_sessions(data_root)["sessions"]
         assert sessions[0].session_id == "mec-npm-new"
         assert sessions[1].session_id == "mec-npm-old"
 
     def test_limit_respected(self, data_root: Path) -> None:
         for i in range(5):
             _write_log(data_root, "npm", f"2026-03-25_1{i}-00-00", f"mec-npm-{i}")
-        assert len(list_sessions(data_root, limit=3)) == 3
+        assert len(list_sessions(data_root, limit=3)["sessions"]) == 3
 
     def test_multiple_tools_sorted_by_filename(self, data_root: Path) -> None:
         _write_log(data_root, "terraform", "2026-03-25_10-00-00", "mec-terraform-1")
         _write_log(data_root, "npm", "2026-03-25_11-00-00", "mec-npm-1")
-        sessions = list_sessions(data_root)
+        sessions = list_sessions(data_root)["sessions"]
         # npm session is newer — must come first despite "terraform" > "npm" alphabetically
         assert sessions[0].session_id == "mec-npm-1"
+
+    def test_recovers_session_with_ansi_escape_sequences(self, data_root: Path) -> None:
+        """Sessions with ANSI control chars in stdout (pre-fix logs) are still readable."""
+        log_dir = data_root / "logs" / "npm"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        # Simulate a log written before escape_json was hardened
+        (log_dir / "2026-03-25_12-00-00.json").write_text(
+            '{"session_id": "mec-npm-ansi", "tool": "npm", '
+            '"execution": {"exit_code": 0, "start_time": "2026-03-25T12:00:00Z"}, '
+            '"output": {"stdout": "10.9.4\\n\x1b[1G\x1b[0K", "stderr": ""}}'
+        )
+        sessions = list_sessions(data_root)["sessions"]
+        assert len(sessions) == 1
+        assert sessions[0].session_id == "mec-npm-ansi"
 
     def test_skips_directory_entries(self, data_root: Path) -> None:
         # Simulate old directory-style sidecar artifacts in logs dir
         fake_dir = data_root / "logs" / "npm" / "2026-03-25_09-00-00.json"
         fake_dir.mkdir(parents=True)
         _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-1")
-        sessions = list_sessions(data_root)
+        sessions = list_sessions(data_root)["sessions"]
         assert all(s.session_id == "mec-npm-1" for s in sessions)
 
 


### PR DESCRIPTION
## Summary

- **Session count**: `list_sessions()` returns `{"sessions": [...], "total": N}` where `total` is the count of *valid* sessions (consistent with `get_stats()`). Sessions page shows "N sessions of M total" when capped by limit.
- **Tool filter completeness**: Sessions page now fetches `/api/stats` to populate the tool filter — previously derived from the capped session list, which missed tools whose most recent sessions fell outside the fetch window (9 tools shown instead of 11).
- **ANSI escape sequences**: `escape_json()` in `log-manager.sh` strips terminal control codes (e.g. `\x1b[1G\x1b[0K`) before writing JSON — fixes sessions like `mec-npm-1774542177` that were silently dropped by the dashboard due to invalid JSON.
- **Backward compatibility**: `_read_json()` retries with ANSI/control-char stripping on `JSONDecodeError`, recovering existing corrupted log files.
- ROADMAP: add "custom image local fallback" to Future Ideas; remove shipped "mec doctor" entry.

## Test plan

- [x] `pytest tests/test_sessions.py` — 17 passed
- [x] `test_total_reflects_valid_sessions_not_raw_files` — empty files not counted
- [x] `test_recovers_session_with_ansi_escape_sequences` — pre-fix logs readable
- [x] Verified `escape_json` strips `\x1b[1G\x1b[0K` from npm output correctly

## Notes

Root cause of 11 vs 9 tools: `availableTools` was `new Set(sessions.value.map(s => s.tool))` — derived only from the 100 most-recent sessions, missing tools like `test-tool`, `yarn-berry`, etc. with only older sessions.