### PR TITLE
feat: add tool stats table, logs/AI status chips to dashboard

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -418,6 +418,7 @@ mec ai status
 Items below are not scheduled — they may become implementation phases once v1.0.0 is stable.
 
 - Shell completion (`mec` CLI, zsh/bash)
+- Decouple from Zsh — make mec compatible with other shells (bash as default/fallback); currently requires Zsh + Oh My Zsh
 - `mec help <tool>` — tool-specific help with examples
 - Homebrew formula (`brew install my-ez-cli`)
 - Claude Code MCP server for my-ez-cli tools

--- a/services/dashboard/frontend/src/components/AIStatus.vue
+++ b/services/dashboard/frontend/src/components/AIStatus.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="feature-status" :class="{ enabled }" :title="enabled ? 'AI analysis enabled — mec ai disable to turn off' : 'AI analysis disabled — run: mec ai enable'">
+    <span class="feature-dot"></span>
+    <span class="feature-label">{{ enabled ? 'AI on' : 'AI off' }}</span>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  enabled: { type: Boolean, default: false },
+})
+</script>
+
+<style scoped>
+.feature-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--mec-text-faint);
+  letter-spacing: 0.04em;
+  cursor: default;
+}
+
+.feature-status.enabled {
+  color: var(--mec-accent-bright);
+}
+
+.feature-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--mec-text-faint);
+  flex-shrink: 0;
+}
+
+.feature-status.enabled .feature-dot {
+  background: var(--mec-accent-bright);
+}
+</style>

--- a/services/dashboard/frontend/src/components/LogsStatus.vue
+++ b/services/dashboard/frontend/src/components/LogsStatus.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="feature-status" :class="{ enabled }" :title="enabled ? 'Logging enabled — mec logs disable to turn off' : 'Logging disabled — run: mec logs enable'">
+    <span class="feature-dot"></span>
+    <span class="feature-label">{{ enabled ? 'logs on' : 'logs off' }}</span>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  enabled: { type: Boolean, default: false },
+})
+</script>
+
+<style scoped>
+.feature-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--mec-text-faint);
+  letter-spacing: 0.04em;
+  cursor: default;
+}
+
+.feature-status.enabled {
+  color: var(--mec-blue);
+}
+
+.feature-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--mec-text-faint);
+  flex-shrink: 0;
+}
+
+.feature-status.enabled .feature-dot {
+  background: var(--mec-blue);
+}
+</style>

--- a/services/dashboard/frontend/src/components/NavBar.vue
+++ b/services/dashboard/frontend/src/components/NavBar.vue
@@ -22,6 +22,10 @@
       </div>
 
       <div class="navbar-right">
+        <LogsStatus :enabled="logsEnabled" />
+        <span class="navbar-sep"></span>
+        <AIStatus :enabled="aiEnabled" />
+        <span class="navbar-sep"></span>
         <WsStatus />
       </div>
     </div>
@@ -29,10 +33,35 @@
 </template>
 
 <script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import WsStatus from './WsStatus.vue'
+import LogsStatus from './LogsStatus.vue'
+import AIStatus from './AIStatus.vue'
+import { useWebSocket } from '../composables/useWebSocket.js'
 
 const route = useRoute()
+const { onRefresh } = useWebSocket()
+
+const logsEnabled = ref(false)
+const aiEnabled = ref(false)
+
+async function fetchFeatureFlags() {
+  try {
+    const res = await fetch('/api/stats')
+    if (res.ok) {
+      const stats = await res.json()
+      logsEnabled.value = stats.logs_enabled ?? false
+      aiEnabled.value = stats.ai_enabled ?? false
+    }
+  } catch (_) { /* silently fail */ }
+}
+
+onMounted(() => {
+  fetchFeatureFlags()
+  const cleanup = onRefresh(fetchFeatureFlags)
+  onUnmounted(cleanup)
+})
 </script>
 
 <style scoped>
@@ -119,5 +148,13 @@ const route = useRoute()
   margin-left: auto;
   display: flex;
   align-items: center;
+  gap: 4px;
+}
+
+.navbar-sep {
+  width: 1px;
+  height: 14px;
+  background: var(--mec-border);
+  margin: 0 6px;
 }
 </style>

--- a/services/dashboard/frontend/src/pages/HomePage.vue
+++ b/services/dashboard/frontend/src/pages/HomePage.vue
@@ -22,6 +22,33 @@
         </div>
       </div>
 
+      <!-- Tool stats table -->
+      <div class="tool-stats-card">
+        <div class="tool-stats-header">Tool Stats</div>
+        <template v-if="loading">
+          <div class="tool-stats-skeleton skeleton-pulse"></div>
+        </template>
+        <table v-else-if="toolStatsRows.length" class="tool-stats-table">
+          <thead>
+            <tr>
+              <th>Tool</th>
+              <th class="col-num">Sessions</th>
+              <th class="col-num">Success</th>
+              <th class="col-num">AI Analyzed</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in toolStatsRows" :key="row.tool">
+              <td class="col-tool">{{ row.tool }}</td>
+              <td class="col-num">{{ row.sessions }}</td>
+              <td class="col-num" :style="{ color: row.successColor }">{{ row.successRate }}</td>
+              <td class="col-num" :style="{ color: row.aiColor }">{{ row.aiRate }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <div v-else class="tool-stats-empty">No data</div>
+      </div>
+
       <!-- Charts row -->
       <div class="charts-grid">
         <!-- Sessions per tool (Bar) -->
@@ -125,6 +152,26 @@ const statCards = computed(() => {
     { label: 'AI Analyzed', value: `${aiRate}%`, color: 'var(--mec-accent-bright)', sub: `${aiDone} sessions` },
     { label: 'Tools Used', value: toolCount.toString(), color: 'var(--mec-blue)', sub: 'unique tools' },
   ]
+})
+
+// --- Tool stats table ---
+const toolStatsRows = computed(() => {
+  if (!stats.value) return []
+  const ts = stats.value.tool_stats ?? {}
+  return Object.entries(ts)
+    .sort(([, a], [, b]) => b.sessions - a.sessions)
+    .map(([tool, d]) => {
+      const successPct = d.sessions ? Math.round((d.success / d.sessions) * 100) : 0
+      const aiPct = d.sessions ? Math.round((d.ai_done / d.sessions) * 100) : 0
+      return {
+        tool,
+        sessions: d.sessions,
+        successRate: `${successPct}%`,
+        aiRate: `${aiPct}%`,
+        successColor: successPct >= 80 ? 'var(--mec-green)' : successPct >= 50 ? 'var(--mec-yellow)' : 'var(--mec-red)',
+        aiColor: aiPct >= 50 ? 'var(--mec-accent-bright)' : 'var(--mec-text-faint)',
+      }
+    })
 })
 
 // --- Chart data ---
@@ -327,6 +374,81 @@ const lineOptions = {
   height: 60px;
   border-radius: 6px;
   background: var(--mec-surface-3);
+}
+
+/* Tool stats table */
+.tool-stats-card {
+  background: var(--mec-surface-1);
+  border: 1px solid var(--mec-border);
+  border-radius: 10px;
+  overflow: hidden;
+  margin-bottom: 28px;
+}
+
+.tool-stats-header {
+  padding: 14px 18px 12px;
+  border-bottom: 1px solid var(--mec-border-subtle);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--mec-text-dim);
+}
+
+.tool-stats-skeleton {
+  height: 120px;
+  margin: 16px;
+  border-radius: 6px;
+  background: var(--mec-surface-3);
+}
+
+.tool-stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.tool-stats-table th {
+  padding: 10px 18px;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--mec-text-faint);
+  border-bottom: 1px solid var(--mec-border-subtle);
+}
+
+.tool-stats-table td {
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--mec-border-subtle);
+  color: var(--mec-text);
+}
+
+.tool-stats-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.tool-stats-table tbody tr:hover td {
+  background: var(--mec-surface-2);
+}
+
+.col-tool {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.col-num {
+  text-align: right !important;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.tool-stats-empty {
+  padding: 24px 18px;
+  color: var(--mec-text-faint);
+  font-size: 13px;
 }
 
 /* Charts */

--- a/services/dashboard/src/sessions.py
+++ b/services/dashboard/src/sessions.py
@@ -333,6 +333,52 @@ def get_session(data_root: Path, session_id: str) -> SessionDetail | None:
     return None
 
 
+def _read_config(data_root: Path) -> dict[str, object]:
+    """Read ~/.my-ez-cli/config.yaml using a minimal YAML subset parser.
+
+    Handles the simple nested structure used by mec config:
+      logs:
+        enabled: true
+      ai:
+        enabled: false
+    """
+    import re
+
+    config_path = data_root / "config.yaml"
+    try:
+        content = config_path.read_text()
+    except OSError as exc:
+        logger.debug("Could not read config %s: %s", config_path, exc)
+        return {}
+
+    result: dict[str, object] = {}
+    current_section: str | None = None
+    for line in content.splitlines():
+        # Top-level key (no leading whitespace, ends with colon)
+        top = re.match(r"^([a-z_][a-z0-9_]*)\s*:\s*$", line)
+        if top:
+            current_section = top.group(1)
+            result[current_section] = {}
+            continue
+        # Nested key under current section
+        if current_section:
+            nested = re.match(r"^\s+([a-z_][a-z0-9_]*)\s*:\s*(.+)$", line)
+            if nested:
+                key, raw = nested.group(1), nested.group(2).strip()
+                val: object
+                if raw.lower() == "true":
+                    val = True
+                elif raw.lower() == "false":
+                    val = False
+                elif re.match(r"^\d+$", raw):
+                    val = int(raw)
+                else:
+                    val = raw.strip("\"'")
+                section: dict[str, object] = result[current_section]  # type: ignore[assignment]
+                section[key] = val
+    return result
+
+
 def get_stats(data_root: Path) -> dict[str, object]:
     """Aggregate statistics across all sessions for the dashboard home page."""
     from datetime import datetime, timedelta
@@ -341,6 +387,8 @@ def get_stats(data_root: Path) -> dict[str, object]:
     by_tool: dict[str, int] = {}
     exit_dist = {"success": 0, "failure": 0}
     ai_rate = {"done": 0, "pending": 0, "none": 0}
+    # Per-tool breakdown: {tool: {"sessions": N, "success": N, "ai_done": N}}
+    tool_stats: dict[str, dict[str, int]] = {}
 
     # Build last-7-days bucket map (today - 6 days through today)
     today = datetime.now(UTC).date()
@@ -358,7 +406,8 @@ def get_stats(data_root: Path) -> dict[str, object]:
         execution: dict[str, object] = data.get("execution", {})  # type: ignore[assignment]
         exit_code_raw = execution.get("exit_code")
         exit_code = int(exit_code_raw) if exit_code_raw is not None else None  # type: ignore[arg-type]
-        if exit_code == 0:
+        is_success = exit_code == 0
+        if is_success:
             exit_dist["success"] += 1
         else:
             exit_dist["failure"] += 1
@@ -366,6 +415,15 @@ def get_stats(data_root: Path) -> dict[str, object]:
         ai_path = _sidecar_path(log_path, data_root)
         status, _, _claude_id = _ai_status(ai_path)
         ai_rate[status] = ai_rate.get(status, 0) + 1
+
+        # Accumulate per-tool breakdown
+        if tool not in tool_stats:
+            tool_stats[tool] = {"sessions": 0, "success": 0, "ai_done": 0}
+        tool_stats[tool]["sessions"] += 1
+        if is_success:
+            tool_stats[tool]["success"] += 1
+        if status == "done":
+            tool_stats[tool]["ai_done"] += 1
 
         # Bucket by date
         ts_str = str(execution.get("start_time", data.get("timestamp", "")))
@@ -379,12 +437,19 @@ def get_stats(data_root: Path) -> dict[str, object]:
 
     last_7_days = [{"date": d, "count": c} for d, c in day_counts.items()]
 
+    config = _read_config(data_root)
+    logs_cfg: dict[str, object] = config.get("logs", {})  # type: ignore[assignment]
+    ai_cfg: dict[str, object] = config.get("ai", {})  # type: ignore[assignment]
+
     return {
         "total_sessions": total,
         "sessions_by_tool": by_tool,
+        "tool_stats": tool_stats,
         "exit_code_distribution": exit_dist,
         "ai_analysis_rate": ai_rate,
         "last_7_days": last_7_days,
+        "logs_enabled": bool(logs_cfg.get("enabled", False)),
+        "ai_enabled": bool(ai_cfg.get("enabled", False)),
     }
 
 

--- a/services/dashboard/tests/test_stats.py
+++ b/services/dashboard/tests/test_stats.py
@@ -125,6 +125,20 @@ class TestGetStats:
         assert dates[0] == str(today - timedelta(days=6))
         assert dates[-1] == str(today)
 
+    def test_logs_enabled_defaults_false_when_no_config(self, tmp_path: Path) -> None:
+        stats = get_stats(tmp_path)
+        assert stats["logs_enabled"] is False
+
+    def test_ai_enabled_defaults_false_when_no_config(self, tmp_path: Path) -> None:
+        stats = get_stats(tmp_path)
+        assert stats["ai_enabled"] is False
+
+    def test_reads_enabled_flags_from_config(self, tmp_path: Path) -> None:
+        (tmp_path / "config.yaml").write_text("logs:\n  enabled: true\nai:\n  enabled: true\n")
+        stats = get_stats(tmp_path)
+        assert stats["logs_enabled"] is True
+        assert stats["ai_enabled"] is True
+
 
 class TestGetTools:
     def test_returns_non_empty_list(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add **Tool Stats table** to Home page showing sessions, success rate, and AI analyzed rate per tool — data from new `tool_stats` field in `/api/stats`
- Add **Logs Status** and **AI Status** chips to the NavBar (next to the existing WsStatus live indicator); chips reflect `logs_enabled` / `ai_enabled` from config and show a tooltip with the mec command to toggle
- Add `logs_enabled` and `ai_enabled` booleans to `/api/stats` response, read from `~/.my-ez-cli/config.yaml` via a minimal YAML subset parser (no PyYAML dependency needed)
- Add per-tool breakdown (`tool_stats`) to `/api/stats`: sessions, success count, ai_done count per tool
- Add "Decouple from Zsh" to ROADMAP Future Ideas

## Test plan

- [x] `pytest tests/` — 30 passed (includes `test_logs_enabled_defaults_false_when_no_config`, `test_ai_enabled_defaults_false_when_no_config`, `test_reads_enabled_flags_from_config`)
- [x] `mec dashboard restart && open http://localhost:4242` — verify tool stats table and status chips

## Notes

`_read_config()` uses a regex-based minimal YAML parser instead of PyYAML to avoid adding a new dependency. Handles the `key:\n  subkey: true/false` pattern used by mec config.