### PR TITLE
docs: backfill CHANGELOG for Phase 3, add README badges + Mermaid diagram, update ROADMAP for Phase 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ data/
 
 # Claude - ignoring local settings
 .claude/*.local.json
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ First release candidate for v1.0.0. Combines Phase 1 (Docker tooling foundation)
 - `bin/mec`: added `_ai_sidecar_exists()` helper; replaced all four `ai_analyses` grep/python checks with sidecar file existence checks
 - `TestWriteAiAnalysis` replaces `TestAppendToLog` in `services/ai/tests/test_claude_response.py`
 
-#### Phase 3 — Dashboard & Web UI
+#### Phase 3.1–3.3 — Dashboard & Web UI
 
 - `mec dashboard` subcommand: `start`, `stop`, `restart`, `status`, `open`, `help`
 - FastAPI + Vue 3 dashboard at `http://localhost:4242` (multi-stage Docker build)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,33 @@ First release candidate for v1.0.0. Combines Phase 1 (Docker tooling foundation)
 - `bin/mec`: added `_ai_sidecar_exists()` helper; replaced all four `ai_analyses` grep/python checks with sidecar file existence checks
 - `TestWriteAiAnalysis` replaces `TestAppendToLog` in `services/ai/tests/test_claude_response.py`
 
+#### Phase 3 — Dashboard & Web UI
+
+- `mec dashboard` subcommand: `start`, `stop`, `restart`, `status`, `open`, `help`
+- FastAPI + Vue 3 dashboard at `http://localhost:4242` (multi-stage Docker build)
+- `/api/sessions` — list sessions (limit=50, newest-first), returns `{sessions, total}`
+- `/api/sessions/{id}` — session detail view
+- `/api/stats` — aggregate stats: total_sessions, sessions_by_tool, tool_stats, exit_code_distribution, ai_analysis_rate, last_7_days, logs_enabled, ai_enabled
+- WebSocket `/ws` — file-system-change hot reload
+- Home page: stat cards, tool stats table, bar/donut/line charts
+- Sessions page: session list with tool/AI/exit-code filters + session ID search
+- Session detail modal: command, cwd, stdout/stderr, AI analysis result
+- NavBar: `LogsStatus` and `AIStatus` chips (reads config), WebSocket live indicator
+- `tool_stats` per-tool breakdown in `/api/stats` (sessions, success, ai_done)
+- `logs_enabled` / `ai_enabled` flags in `/api/stats` (reads `~/.my-ez-cli/config.yaml`)
+- ANSI/control-char stripping in `_read_json()` — recovers corrupted log files
+- Session total fix: `total` counts only valid JSON sessions, not raw file count
+- Tool filter sourced from `/api/stats` (all-time) not just the current fetch window
+
+#### Phase 3.4 — Health Check
+
+- `mec doctor` subcommand: full environment health check (Docker, images, config, credentials, dashboard)
+- Exit code 0 = healthy, non-zero = one or more checks failed
+
 ### Changed
 
+- `escape_json()` in `bin/utils/log-manager.sh` now strips ANSI escape sequences before writing stdout/stderr to log JSON
+- `/api/sessions` response shape changed from plain array to `{"sessions": [...], "total": N}`
 - All bin scripts use `get_container_name()` and `get_container_labels()` from `common.sh`
 - Path resolution fixed across all scripts using `SCRIPT_DIR`-based sourcing
 - `setup.sh` rewritten with full command-line and interactive multi-select support

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # My Ez CLI
 
+[![CI](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/test.yml/badge.svg)](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/test.yml)
+[![Docker Builds](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/docker-build-dashboard.yml/badge.svg)](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/docker-build-dashboard.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 CLI tools over Docker — managed by `mec`.
 
 > Docker-based dev tools + AI analysis powered by Claude Code. See [docs/ROADMAP.md](./docs/ROADMAP.md) for current status.
@@ -205,6 +209,21 @@ mec dashboard stop
 mec config set ai.dashboard.port 8080
 mec dashboard restart
 ```
+
+<details>
+<summary>Architecture overview</summary>
+
+```mermaid
+flowchart TD
+    A["bin/* tool scripts\n(node, aws, terraform, …)"] -->|"exec_with_ai()"| B["log-manager.sh\nimmutable log\n~/.my-ez-cli/logs/<tool>/<ts>.json"]
+    B -->|"MEC_AI_ENABLED=true"| C["analyze_with_claude()\nbackground subshell"]
+    C -->|"docker run"| D["Claude Code CLI\n--output-format json"]
+    D -->|"stdout JSON"| E["parse-claude-response\n(services/ai middleware)"]
+    E -->|"sidecar"| F["~/.my-ez-cli/ai-analyses/<tool>/<ts>.json"]
+    B & F --> G["mec dashboard\nFastAPI + Vue 3\nlocalhost:4242"]
+```
+
+</details>
 
 For detailed AI documentation, see [docs/AI_INTEGRATION.md](./docs/AI_INTEGRATION.md).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/test.yml/badge.svg)](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/test.yml)
 [![Docker Builds](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/docker-build-dashboard.yml/badge.svg)](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/docker-build-dashboard.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 
 CLI tools over Docker — managed by `mec`.
 

--- a/docs/LOG_FORMAT.md
+++ b/docs/LOG_FORMAT.md
@@ -141,9 +141,14 @@ When `MEC_AI_ENABLED=true` and Claude Code runs after a tool execution, an AI si
   "log_session_id": "mec-node-1705318245",
   "log_file": "/Users/username/.my-ez-cli/logs/node/2026-01-15_10-30-45.json",
   "analyses": {
-    "abc-123-def": {
-      "timestamp": "2026-02-20T10:30:45Z",
-      "result": "The command succeeded. No issues found."
+    "<claude_session_id>": {
+      "timestamp": "2026-03-26T14:30:45.123456+00:00",
+      "result": "Analysis text…",
+      "execution_time_ms": 12450,
+      "tokens": {
+        "input": 3200,
+        "output": 512
+      }
     }
   }
 }
@@ -152,6 +157,9 @@ When `MEC_AI_ENABLED=true` and Claude Code runs after a tool execution, an AI si
 - `log_session_id`: tool session ID (matches the log file's `session_id`)
 - `log_file`: absolute path to the corresponding tool log file
 - `analyses`: dict keyed by Claude session ID — allows re-analysis without overwriting
+- `execution_time_ms` — wall-clock milliseconds from start to end of Claude Code analysis
+- `tokens.input` — input token count from Claude's `usage` response field
+- `tokens.output` — output token count from Claude's `usage` response field
 
 `mec logs list` and `mec logs stats` report the `AI` column by checking for the sidecar file — the tool log is never read for this purpose.
 

--- a/docs/LOG_FORMAT.md
+++ b/docs/LOG_FORMAT.md
@@ -154,6 +154,8 @@ When `MEC_AI_ENABLED=true` and Claude Code runs after a tool execution, an AI si
 }
 ```
 
+#### Field Descriptions
+
 - `log_session_id`: tool session ID (matches the log file's `session_id`)
 - `log_file`: absolute path to the corresponding tool log file
 - `analyses`: dict keyed by Claude session ID — allows re-analysis without overwriting
@@ -273,6 +275,7 @@ Example:
 
 ## Change History
 
+- **2026-03-26**: Added `execution_time_ms`, `tokens.input`, `tokens.output` to AI sidecar analyses entries
 - **2026-02-20**: AI sidecar directory; immutable log files
   - Tool log files are immutable after finalization
   - AI analyses written to parallel `ai-analyses/` directory tree

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Status:** Phase 3.5 In Progress - v1.0.0 Release Candidate
 **Target:** First Stable Release (v1.0.0)
 **Previous Versions:** 0.x.y (beta releases)
-**Phase 1 Completed:** 2025-01-20
+**Phase 1 Completed:** 2026-01-20
 **Phase 2 Completed:** 2026-02-16
 **Phase 2.9 Completed:** 2026-02-20
 **Phase 3 Started:** 2026-03-24
@@ -156,7 +156,7 @@ my-ez-cli/
 
 ### ✅ Completed Features
 
-**Phase 1 - Foundation (Completed: 2025-01-20)**
+**Phase 1 - Foundation (Completed: 2026-01-20)**
 - ✅ Path resolution fixes (`common.sh` with symlink-safe utilities)
 - ✅ Multi-select installation in `setup.sh`
 - ✅ Comprehensive test framework (73 tests: 65 unit, 8 integration)
@@ -213,7 +213,7 @@ mec ai status
 
 **Status:** Complete
 **Priority:** P0 (Critical)
-**Completed:** 2025-01-20
+**Completed:** 2026-01-20
 **Goal:** Fix critical issues, establish solid base
 
 **Completed Tasks:**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Status:** Phase 3.5 In Progress - v1.0.0 Release Candidate
 **Target:** First Stable Release (v1.0.0)
 **Previous Versions:** 0.x.y (beta releases)
-**Phase 1 Completed:** 2026-01-20
+**Phase 1 Completed:** 2025-01-20
 **Phase 2 Completed:** 2026-02-16
 **Phase 2.9 Completed:** 2026-02-20
 **Phase 3 Started:** 2026-03-24
@@ -428,6 +428,9 @@ mec ai status
 - ✅ `mec dashboard rebuild` + `restart --rebuild`
 - ✅ Session search extended to command + cwd
 - ✅ NavBar status chips auto-refresh fix
+
+**Deliverables:**
+- *(to be confirmed on completion)*
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # My Ez CLI - v1.0.0 Roadmap
 
-**Status:** Phase 3.4 Complete - v1.0.0 Release Candidate
+**Status:** Phase 3.5 In Progress - v1.0.0 Release Candidate
 **Target:** First Stable Release (v1.0.0)
 **Previous Versions:** 0.x.y (beta releases)
 **Phase 1 Completed:** 2026-01-20
@@ -410,6 +410,24 @@ mec ai status
 **Deliverables:**
 - Single `mec doctor` command for full environment health check
 - Structured pass/warn/fail output with actionable hints
+
+---
+
+### Phase 3.5: Execution Metrics & Session Insight ⏳
+
+**Status:** In Progress
+**Priority:** P1 (High)
+**Started:** 2026-03-26
+**Goal:** Capture AI execution timing and token usage in sidecars; ship `mec purge`; improve dashboard UX; project documentation hygiene.
+
+**Completed Tasks:**
+- ✅ CHANGELOG backfill (Phase 3.1–3.4 + ad-hoc fixes)
+- ✅ README status badges + Mermaid architecture diagram
+- ✅ AI sidecar schema extended: `execution_time_ms`, `tokens.input`, `tokens.output`
+- ✅ `mec purge` subcommand
+- ✅ `mec dashboard rebuild` + `restart --rebuild`
+- ✅ Session search extended to command + cwd
+- ✅ NavBar status chips auto-refresh fix
 
 ---
 


### PR DESCRIPTION
## Summary

- Backfill CHANGELOG with Phase 3.1–3.3 (Dashboard & Web UI) and Phase 3.4 (mec doctor) entries + Changed section updates (ANSI stripping, sessions API shape)
- Add CI, Docker Builds, and MIT License status badges to README
- Add Mermaid architecture diagram in README AI Features section (collapsible `<details>`)
- Update ROADMAP status to Phase 3.5 In Progress; add Phase 3.5 section with goal and completed tasks checklist
- Update LOG_FORMAT.md sidecar schema with new `execution_time_ms` and `tokens` fields (documents Branch 2)

## Test plan

- [ ] `cat CHANGELOG.md | head -120` — verify Phase 3.1–3.3 and Phase 3.4 entries present
- [ ] `cat README.md | head -10` — verify badges present
- [ ] Open README.md on GitHub to confirm Mermaid diagram renders
- [ ] `grep "Phase 3.5" docs/ROADMAP.md` — verify section present
- [ ] `grep execution_time_ms docs/LOG_FORMAT.md` — verify field documented

## Notes

Part of Phase 3.5. No code changes — documentation only.