### PR TITLE
feat: add mec purge subcommand for log and AI analysis cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,11 @@ jobs:
           ./bin/mec dashboard help
           echo "✓ mec dashboard help passed"
 
+      - name: Test mec purge help
+        run: |
+          ./bin/mec purge help
+          echo "✓ mec purge help passed"
+
   # Unit tests - run in parallel for faster execution
   unit-tests:
     runs-on: ubuntu-latest
@@ -166,6 +171,7 @@ jobs:
           - doctor
           - node
           - npm
+          - purge
           - python
           - setup
           - terraform

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ CLI tools over Docker — managed by `mec`.
   - [AI Analysis](#ai-analysis----mec-ai)
   - [Dashboard](#dashboard----mec-dashboard)
   - [Health Check](#health-check----mec-doctor)
+  - [Purge](#purge----mec-purge)
   - [Claude Code](#claude-code----mec-claude)
 - [AI Features](#ai-features)
   - [TUI](#tui----mec-ai)
@@ -137,6 +138,17 @@ mec doctor               # Check Docker, Zsh, tools, AI, dashboard, and data dir
 ```
 
 Prints a structured report with ✓ pass / ⚠ warn / ✗ fail per check and a summary. Exits `1` if any check fails — scriptable.
+
+### Purge — `mec purge`
+
+```shell
+mec purge data                           # Delete all logs + AI analyses (interactive)
+mec purge data --dry-run                 # Preview what would be deleted
+mec purge data --tool node               # Only node logs + analyses
+mec purge data --older-than 30           # Only files older than 30 days
+mec purge data --only-logs --tool aws    # Only aws logs (keep AI analyses)
+mec purge data -y                        # Skip confirmation prompt
+```
 
 ### Claude Code — `mec claude`
 

--- a/bin/mec
+++ b/bin/mec
@@ -1417,7 +1417,7 @@ mec_purge() {
     fi
 
     case "$subcmd" in
-        all)
+        data)
             local log_dir="${HOME}/.my-ez-cli/logs"
             local ai_dir="${HOME}/.my-ez-cli/ai-analyses"
 
@@ -1476,7 +1476,7 @@ mec_purge() {
 Usage: mec purge <command> [flags]
 
 Commands:
-  all       Delete log and AI analysis files (interactive by default)
+  data      Delete log and AI analysis files (interactive by default)
 
 Flags:
   --tool <name>        Only purge files for a specific tool (e.g. node, aws)
@@ -1487,12 +1487,12 @@ Flags:
   -y, --yes            Skip confirmation prompts
 
 Examples:
-  mec purge all                           # purge all logs + AI analyses (interactive)
-  mec purge all --dry-run                 # preview only
-  mec purge all --tool node               # only node logs + analyses
-  mec purge all --older-than 30           # only files older than 30 days
-  mec purge all --only-logs --tool aws    # only aws logs (keep AI analyses)
-  mec purge all -y                        # skip confirmation
+  mec purge data                           # purge all logs + AI analyses (interactive)
+  mec purge data --dry-run                 # preview only
+  mec purge data --tool node               # only node logs + analyses
+  mec purge data --older-than 30           # only files older than 30 days
+  mec purge data --only-logs --tool aws    # only aws logs (keep AI analyses)
+  mec purge data -y                        # skip confirmation
 EOF
             ;;
         *)

--- a/bin/mec
+++ b/bin/mec
@@ -1418,8 +1418,9 @@ mec_purge() {
 
     case "$subcmd" in
         data)
-            local log_dir="${HOME}/.my-ez-cli/logs"
-            local ai_dir="${HOME}/.my-ez-cli/ai-analyses"
+            local _data_dir="${MEC_DATA_DIR:-${HOME}/.my-ez-cli}"
+            local log_dir="${MEC_LOG_DIR:-${_data_dir}/logs}"
+            local ai_dir="${_data_dir}/ai-analyses"
 
             local purge_logs=1 purge_ai=1
             [ "$opt_only_ai"   -eq 1 ] && purge_logs=0

--- a/bin/mec
+++ b/bin/mec
@@ -1395,9 +1395,26 @@ mec_purge() {
             --only-ai-analyses) opt_only_ai=1;        shift ;;
             --dry-run)          opt_dry_run=1;        shift ;;
             -y|--yes)           opt_yes=1;            shift ;;
-            *)                  break ;;
+            *)
+                echo "Unknown flag: $1" >&2
+                echo "Run 'mec purge help' for usage" >&2
+                return 1
+                ;;
         esac
     done
+
+    # Validate --older-than is a positive integer
+    if [ -n "$opt_older_than" ] && ! printf '%s' "$opt_older_than" | grep -qE '^[0-9]+$'; then
+        echo "Error: --older-than requires a positive integer (days), got: $opt_older_than" >&2
+        return 1
+    fi
+
+    # Validate --tool has no path separators
+    if [ -n "$opt_tool" ]; then
+        case "$opt_tool" in
+            */* | *..*) echo "Error: --tool must not contain path separators or '..'" >&2; return 1 ;;
+        esac
+    fi
 
     case "$subcmd" in
         all)
@@ -1408,8 +1425,8 @@ mec_purge() {
             [ "$opt_only_ai"   -eq 1 ] && purge_logs=0
             [ "$opt_only_logs" -eq 1 ] && purge_ai=0
 
+            local _label _rest _dir _enabled _find_args _count _answer
             for _entry in "logs:${log_dir}:${purge_logs}" "ai-analyses:${ai_dir}:${purge_ai}"; do
-                local _label _dir _enabled _rest
                 _label="${_entry%%:*}"
                 _rest="${_entry#*:}"
                 _dir="${_rest%%:*}"
@@ -1417,7 +1434,6 @@ mec_purge() {
                 [ "$_enabled" -eq 0 ] && continue
                 [ ! -d "$_dir" ] && continue
 
-                local _find_args
                 _find_args=()
                 if [ -n "$opt_tool" ]; then
                     _find_args+=(-path "*/${opt_tool}/*.json")
@@ -1427,17 +1443,17 @@ mec_purge() {
                 _find_args+=(! -name "*.bak")
                 [ -n "$opt_older_than" ] && _find_args+=(-mtime "+${opt_older_than}")
 
-                local _files _count
-                _files=$(find "$_dir" "${_find_args[@]}" 2>/dev/null || true)
-                if [ -z "$_files" ]; then
+                # Count matching files safely
+                _count=$(find "$_dir" "${_find_args[@]}" 2>/dev/null | wc -l | tr -d ' ')
+
+                if [ "$_count" -eq 0 ]; then
                     echo "No files to purge in $_label."
                     continue
                 fi
-                _count=$(printf '%s\n' "$_files" | wc -l | tr -d ' ')
 
                 if [ "$opt_dry_run" -eq 1 ]; then
                     echo "[dry-run] Would delete $_count file(s) from $_dir"
-                    printf '%s\n' "$_files" | head -5
+                    find "$_dir" "${_find_args[@]}" 2>/dev/null | head -5
                     [ "$_count" -gt 5 ] && echo "  ... and $(( _count - 5 )) more"
                     continue
                 fi
@@ -1451,7 +1467,7 @@ mec_purge() {
                     esac
                 fi
 
-                printf '%s\n' "$_files" | xargs rm -f
+                find "$_dir" "${_find_args[@]}" -print0 2>/dev/null | xargs -0 rm -f
                 echo "Deleted $_count file(s) from $_dir"
             done
             ;;

--- a/bin/mec
+++ b/bin/mec
@@ -54,6 +54,7 @@ Commands:
   ai                  AI analysis (Claude Code)
   dashboard           Log and AI analysis web UI (start|stop|status|open)
   doctor              Health check (Docker, Zsh, tools, AI, dashboard, data dir)
+  purge               Purge log and AI analysis files
   logs                Log management
   claude              Run Claude Code
   claude firewall     Manage Claude Code container firewall
@@ -1378,6 +1379,115 @@ _mec_doctor_run() {
 }
 
 # ----------------------------------------------------------------------------
+# Purge Commands
+# ----------------------------------------------------------------------------
+
+mec_purge() {
+    local subcmd="${1:-help}"
+    shift 2>/dev/null || true
+
+    local opt_tool="" opt_older_than="" opt_only_logs=0 opt_only_ai=0 opt_dry_run=0 opt_yes=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --tool)             opt_tool="$2";        shift 2 ;;
+            --older-than)       opt_older_than="$2";  shift 2 ;;
+            --only-logs)        opt_only_logs=1;      shift ;;
+            --only-ai-analyses) opt_only_ai=1;        shift ;;
+            --dry-run)          opt_dry_run=1;        shift ;;
+            -y|--yes)           opt_yes=1;            shift ;;
+            *)                  break ;;
+        esac
+    done
+
+    case "$subcmd" in
+        all)
+            local log_dir="${HOME}/.my-ez-cli/logs"
+            local ai_dir="${HOME}/.my-ez-cli/ai-analyses"
+
+            local purge_logs=1 purge_ai=1
+            [ "$opt_only_ai"   -eq 1 ] && purge_logs=0
+            [ "$opt_only_logs" -eq 1 ] && purge_ai=0
+
+            for _entry in "logs:${log_dir}:${purge_logs}" "ai-analyses:${ai_dir}:${purge_ai}"; do
+                local _label _dir _enabled _rest
+                _label="${_entry%%:*}"
+                _rest="${_entry#*:}"
+                _dir="${_rest%%:*}"
+                _enabled="${_rest##*:}"
+                [ "$_enabled" -eq 0 ] && continue
+                [ ! -d "$_dir" ] && continue
+
+                local _find_args
+                _find_args=()
+                if [ -n "$opt_tool" ]; then
+                    _find_args+=(-path "*/${opt_tool}/*.json")
+                else
+                    _find_args+=(-name "*.json")
+                fi
+                _find_args+=(! -name "*.bak")
+                [ -n "$opt_older_than" ] && _find_args+=(-mtime "+${opt_older_than}")
+
+                local _files _count
+                _files=$(find "$_dir" "${_find_args[@]}" 2>/dev/null || true)
+                if [ -z "$_files" ]; then
+                    echo "No files to purge in $_label."
+                    continue
+                fi
+                _count=$(printf '%s\n' "$_files" | wc -l | tr -d ' ')
+
+                if [ "$opt_dry_run" -eq 1 ]; then
+                    echo "[dry-run] Would delete $_count file(s) from $_dir"
+                    printf '%s\n' "$_files" | head -5
+                    [ "$_count" -gt 5 ] && echo "  ... and $(( _count - 5 )) more"
+                    continue
+                fi
+
+                if [ "$opt_yes" -eq 0 ]; then
+                    printf "Delete %s file(s) from %s? [y/N] " "$_count" "$_dir"
+                    read -r _answer
+                    case "$_answer" in
+                        y|Y) ;;
+                        *) echo "Skipped $_label."; continue ;;
+                    esac
+                fi
+
+                printf '%s\n' "$_files" | xargs rm -f
+                echo "Deleted $_count file(s) from $_dir"
+            done
+            ;;
+        help|--help|-h|"")
+            cat <<'EOF'
+Usage: mec purge <command> [flags]
+
+Commands:
+  all       Delete log and AI analysis files (interactive by default)
+
+Flags:
+  --tool <name>        Only purge files for a specific tool (e.g. node, aws)
+  --older-than <days>  Only purge files older than N days
+  --only-logs          Only purge ~/.my-ez-cli/logs/
+  --only-ai-analyses   Only purge ~/.my-ez-cli/ai-analyses/
+  --dry-run            Preview what would be deleted without deleting
+  -y, --yes            Skip confirmation prompts
+
+Examples:
+  mec purge all                           # purge all logs + AI analyses (interactive)
+  mec purge all --dry-run                 # preview only
+  mec purge all --tool node               # only node logs + analyses
+  mec purge all --older-than 30           # only files older than 30 days
+  mec purge all --only-logs --tool aws    # only aws logs (keep AI analyses)
+  mec purge all -y                        # skip confirmation
+EOF
+            ;;
+        *)
+            echo "Unknown purge command: $subcmd" >&2
+            echo "Run 'mec purge help' for usage" >&2
+            return 1
+            ;;
+    esac
+}
+
+# ----------------------------------------------------------------------------
 # Main Dispatch
 # ----------------------------------------------------------------------------
 
@@ -1425,6 +1535,10 @@ case "$COMMAND" in
     doctor)
         shift
         mec_doctor "${@}"
+        ;;
+    purge)
+        shift
+        mec_purge "$@"
         ;;
     version|--version|-v)
         show_version

--- a/tests/unit/test-purge.bats
+++ b/tests/unit/test-purge.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# ============================================================================
+# Tests for mec purge subcommand
+# ============================================================================
+
+BASEDIR="$(cd "$(dirname "$BATS_TEST_DIRNAME")/.." && pwd)"
+
+setup() {
+    export MEC_BASE_DIR="$BASEDIR"
+
+    TEST_DATA_DIR=$(mktemp -d)
+    export MEC_DATA_DIR="$TEST_DATA_DIR"
+    export MEC_LOG_DIR="$TEST_DATA_DIR/logs"
+}
+
+teardown() {
+    [ -n "$TEST_DATA_DIR" ] && rm -rf "$TEST_DATA_DIR"
+}
+
+# ============================================================================
+# mec purge help
+# ============================================================================
+
+@test "bin/mec has mec_purge function" {
+    grep -q 'mec_purge' "$BASEDIR/bin/mec"
+}
+
+@test "mec purge --help prints usage" {
+    run "$BASEDIR/bin/mec" purge --help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage: mec purge" ]]
+}
+
+@test "mec purge help prints usage" {
+    run "$BASEDIR/bin/mec" purge help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage: mec purge" ]]
+}
+
+@test "mec purge help lists data subcommand" {
+    run "$BASEDIR/bin/mec" purge help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "data" ]]
+}
+
+@test "mec purge help lists available flags" {
+    run "$BASEDIR/bin/mec" purge help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "--tool" ]]
+    [[ "$output" =~ "--older-than" ]]
+    [[ "$output" =~ "--dry-run" ]]
+    [[ "$output" =~ "--only-logs" ]]
+    [[ "$output" =~ "--only-ai-analyses" ]]
+}
+
+@test "mec purge unknown subcommand exits non-zero" {
+    run "$BASEDIR/bin/mec" purge all
+    [ "$status" -ne 0 ]
+}
+
+# ============================================================================
+# mec purge data --dry-run (no actual deletion)
+# ============================================================================
+
+@test "mec purge data --dry-run with empty dirs prints no-files message" {
+    mkdir -p "$TEST_DATA_DIR/logs" "$TEST_DATA_DIR/ai-analyses"
+    run "$BASEDIR/bin/mec" purge data --dry-run
+    [ "$status" -eq 0 ]
+}
+
+@test "mec purge data --dry-run lists files without deleting" {
+    mkdir -p "$TEST_DATA_DIR/logs/node"
+    echo '{"session_id":"s1"}' > "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json"
+
+    run "$BASEDIR/bin/mec" purge data --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "[dry-run]" ]]
+    # File must still exist after dry run
+    [ -f "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json" ]
+}
+
+# ============================================================================
+# mec purge data -y (non-interactive deletion)
+# ============================================================================
+
+@test "mec purge data -y deletes log files" {
+    mkdir -p "$TEST_DATA_DIR/logs/node"
+    echo '{"session_id":"s1"}' > "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json"
+
+    run "$BASEDIR/bin/mec" purge data -y
+    [ "$status" -eq 0 ]
+    [ ! -f "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json" ]
+}
+
+@test "mec purge data --only-logs -y deletes only log files" {
+    mkdir -p "$TEST_DATA_DIR/logs/node" "$TEST_DATA_DIR/ai-analyses/node"
+    echo '{"session_id":"s1"}' > "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json"
+    echo '{"analyses":{}}' > "$TEST_DATA_DIR/ai-analyses/node/2026-01-01_00-00-00.json"
+
+    run "$BASEDIR/bin/mec" purge data --only-logs -y
+    [ "$status" -eq 0 ]
+    [ ! -f "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json" ]
+    [ -f "$TEST_DATA_DIR/ai-analyses/node/2026-01-01_00-00-00.json" ]
+}
+
+@test "mec purge data --only-ai-analyses -y deletes only AI analyses" {
+    mkdir -p "$TEST_DATA_DIR/logs/node" "$TEST_DATA_DIR/ai-analyses/node"
+    echo '{"session_id":"s1"}' > "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json"
+    echo '{"analyses":{}}' > "$TEST_DATA_DIR/ai-analyses/node/2026-01-01_00-00-00.json"
+
+    run "$BASEDIR/bin/mec" purge data --only-ai-analyses -y
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json" ]
+    [ ! -f "$TEST_DATA_DIR/ai-analyses/node/2026-01-01_00-00-00.json" ]
+}
+
+@test "mec purge data --tool node -y deletes only node files" {
+    mkdir -p "$TEST_DATA_DIR/logs/node" "$TEST_DATA_DIR/logs/aws"
+    echo '{"session_id":"s1"}' > "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json"
+    echo '{"session_id":"s2"}' > "$TEST_DATA_DIR/logs/aws/2026-01-01_00-00-00.json"
+
+    run "$BASEDIR/bin/mec" purge data --tool node -y
+    [ "$status" -eq 0 ]
+    [ ! -f "$TEST_DATA_DIR/logs/node/2026-01-01_00-00-00.json" ]
+    [ -f "$TEST_DATA_DIR/logs/aws/2026-01-01_00-00-00.json" ]
+}
+
+@test "mec purge data rejects invalid --tool path traversal" {
+    run "$BASEDIR/bin/mec" purge data --tool "../etc" -y
+    [ "$status" -ne 0 ]
+}
+
+@test "mec purge data rejects non-numeric --older-than" {
+    run "$BASEDIR/bin/mec" purge data --older-than "abc" -y
+    [ "$status" -ne 0 ]
+}
+
+@test "mec purge data rejects unknown flags" {
+    run "$BASEDIR/bin/mec" purge data --unknown-flag -y
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

- Add `mec purge all` subcommand that deletes files from `~/.my-ez-cli/logs/` and/or `~/.my-ez-cli/ai-analyses/`
- Flags: `--tool <name>`, `--older-than <days>`, `--only-logs`, `--only-ai-analyses`, `--dry-run`, `-y`/`--yes`
- Interactive y/N confirmation by default; `--dry-run` previews without deleting
- Hardened: unknown flags error, `--older-than` validates numeric, `--tool` validated against path traversal, uses `find -print0 | xargs -0` for safe filename handling

## Test plan

- [ ] `mec purge help` — shows usage with all flags and examples
- [ ] `mec purge all --dry-run` — lists files without deleting
- [ ] `mec purge all --tool node --dry-run` — shows only node files
- [ ] `mec purge all --older-than foo` — prints error "requires a positive integer"
- [ ] `mec purge all --unknownflag` — prints "Unknown flag" error
- [ ] `mec purge all --only-logs --dry-run` — shows only logs/, skips ai-analyses/

## Notes

`mec purge` is listed in `mec help` after `doctor`.