### PR TITLE
feat: dashboard rebuild cmd, NavBar auto-refresh fix, extended session search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,11 @@ jobs:
           ./bin/mec purge help
           echo "✓ mec purge help passed"
 
+      - name: Test mec dashboard rebuild help
+        run: |
+          ./bin/mec dashboard help | grep -q 'rebuild'
+          echo "✓ mec dashboard rebuild documented in help"
+
   # Unit tests - run in parallel for faster execution
   unit-tests:
     runs-on: ubuntu-latest
@@ -168,6 +173,7 @@ jobs:
         test-suite:
           - aws
           - common-utils
+          - dashboard
           - doctor
           - node
           - npm

--- a/bin/mec
+++ b/bin/mec
@@ -1157,7 +1157,8 @@ Usage: mec dashboard <command>
 Commands:
   start     Start the dashboard (API + UI served from the same container)
   stop      Stop and remove the dashboard container
-  restart   Stop then start the dashboard container
+  restart   Stop then start (add --rebuild to also rebuild the image first)
+  rebuild   Build the dashboard Docker image locally
   status    Show dashboard container status
   open      Open the dashboard in the default browser
   help      Show this help message
@@ -1169,12 +1170,28 @@ Configuration:
 Examples:
   mec dashboard start
   mec dashboard restart
+  mec dashboard rebuild
+  mec dashboard restart --rebuild
   mec dashboard open
   mec dashboard stop
 EOF
             ;;
+        rebuild)
+            local _dockerfile_dir
+            _dockerfile_dir="${BASE_DIR}/docker/dashboard"
+            if [ ! -f "$_dockerfile_dir/Dockerfile" ]; then
+                echo "[mec] ERROR: Dockerfile not found at $_dockerfile_dir/Dockerfile" >&2
+                return 1
+            fi
+            echo "Building $MEC_IMAGE_DASHBOARD ..."
+            docker build -t "$MEC_IMAGE_DASHBOARD" "$_dockerfile_dir"
+            echo "Build complete. Run 'mec dashboard restart' to use the new image."
+            ;;
         restart)
+            local _do_rebuild=0
+            for _arg in "$@"; do [ "$_arg" = "--rebuild" ] && _do_rebuild=1; done
             mec_dashboard "stop"
+            [ "$_do_rebuild" -eq 1 ] && mec_dashboard "rebuild"
             mec_dashboard "start"
             ;;
         *)

--- a/services/dashboard/frontend/src/components/NavBar.vue
+++ b/services/dashboard/frontend/src/components/NavBar.vue
@@ -57,10 +57,15 @@ async function fetchFeatureFlags() {
   } catch (_) { /* silently fail */ }
 }
 
+let pollTimer = null
 onMounted(() => {
   fetchFeatureFlags()
-  const cleanup = onRefresh(fetchFeatureFlags)
-  onUnmounted(cleanup)
+  pollTimer = setInterval(fetchFeatureFlags, 30_000)
+})
+const cleanupRefresh = onRefresh(fetchFeatureFlags)
+onUnmounted(() => {
+  cleanupRefresh()
+  if (pollTimer) clearInterval(pollTimer)
 })
 </script>
 

--- a/services/dashboard/frontend/src/composables/useSessions.js
+++ b/services/dashboard/frontend/src/composables/useSessions.js
@@ -62,7 +62,7 @@ export function useSessions() {
       if (search.trim()) {
         const q = search.trim().toLowerCase()
         result = result.filter((s) =>
-          s.session_id.toLowerCase().includes(q) ||
+          (s.session_id ?? '').toLowerCase().includes(q) ||
           (s.command ?? '').toLowerCase().includes(q) ||
           (s.cwd ?? '').toLowerCase().includes(q)
         )

--- a/services/dashboard/frontend/src/composables/useSessions.js
+++ b/services/dashboard/frontend/src/composables/useSessions.js
@@ -37,7 +37,7 @@ export function useSessions() {
    * @param {string[]} [filters.tools] - Tool names to include (empty = all)
    * @param {string} [filters.aiStatus] - 'all'|'done'|'pending'|'none'
    * @param {string} [filters.exitCode] - 'all'|'success'|'failure'
-   * @param {string} [filters.search] - Text filter on session_id
+   * @param {string} [filters.search] - Text search across session_id, command, and cwd
    */
   function makeFiltered(filters) {
     return computed(() => {
@@ -61,7 +61,11 @@ export function useSessions() {
 
       if (search.trim()) {
         const q = search.trim().toLowerCase()
-        result = result.filter((s) => s.session_id.toLowerCase().includes(q))
+        result = result.filter((s) =>
+          s.session_id.toLowerCase().includes(q) ||
+          (s.command ?? '').toLowerCase().includes(q) ||
+          (s.cwd ?? '').toLowerCase().includes(q)
+        )
       }
 
       return result

--- a/services/dashboard/frontend/src/composables/useSessions.test.js
+++ b/services/dashboard/frontend/src/composables/useSessions.test.js
@@ -89,4 +89,36 @@ describe('useSessions — makeFiltered', () => {
     expect(filtered.value).toHaveLength(1)
     expect(filtered.value[0].session_id).toBe('mec-node-001')
   })
+
+  it('matches sessions by command', async () => {
+    const { useSessions } = await import('./useSessions.js')
+    const { sessions, makeFiltered } = useSessions()
+    sessions.value = [
+      { session_id: 'mec-node-1', tool: 'node', command: 'node index.js', cwd: '/home', exit_code: 0, ai_status: 'none' },
+    ]
+    const filtered = makeFiltered({ get search() { return 'index.js' } })
+    expect(filtered.value).toHaveLength(1)
+  })
+
+  it('matches sessions by cwd', async () => {
+    const { useSessions } = await import('./useSessions.js')
+    const { sessions, makeFiltered } = useSessions()
+    sessions.value = [
+      { session_id: 'mec-node-1', tool: 'node', command: 'node -e x', cwd: '/home/myproject', exit_code: 0, ai_status: 'none' },
+    ]
+    const filtered = makeFiltered({ get search() { return 'myproject' } })
+    expect(filtered.value).toHaveLength(1)
+  })
+
+  it('does not match sessions where search term is only in tool name', async () => {
+    const { useSessions } = await import('./useSessions.js')
+    const { sessions, makeFiltered } = useSessions()
+    sessions.value = [
+      { session_id: 'mec-terraform-1', tool: 'terraform', command: 'terraform plan', cwd: '/infra', exit_code: 0, ai_status: 'none' },
+    ]
+    const filtered = makeFiltered({ get search() { return 'terraform' } })
+    // 'terraform' appears in command 'terraform plan' — should match
+    // This test verifies command matching works for a tool name that appears in command
+    expect(filtered.value).toHaveLength(1)
+  })
 })

--- a/services/dashboard/frontend/src/composables/useSessions.test.js
+++ b/services/dashboard/frontend/src/composables/useSessions.test.js
@@ -110,7 +110,7 @@ describe('useSessions — makeFiltered', () => {
     expect(filtered.value).toHaveLength(1)
   })
 
-  it('does not match sessions where search term is only in tool name', async () => {
+  it('matches when search term appears in command even if it is also the tool name', async () => {
     const { useSessions } = await import('./useSessions.js')
     const { sessions, makeFiltered } = useSessions()
     sessions.value = [

--- a/services/dashboard/frontend/src/pages/SessionsPage.vue
+++ b/services/dashboard/frontend/src/pages/SessionsPage.vue
@@ -19,7 +19,7 @@
           <i class="pi pi-search search-icon"></i>
           <InputText
             v-model="search"
-            placeholder="Search session ID…"
+            placeholder="Search sessions…"
             class="search-input"
           />
         </div>

--- a/services/dashboard/frontend/tests/e2e/dashboard.spec.js
+++ b/services/dashboard/frontend/tests/e2e/dashboard.spec.js
@@ -17,7 +17,7 @@ test.describe('mec dashboard', () => {
 
   test('sessions page search input works', async ({ page }) => {
     await page.goto('/sessions')
-    const search = page.locator('input[placeholder="Search session ID…"]')
+    const search = page.locator('input[placeholder="Search sessions…"]')
     await expect(search).toBeVisible()
     await search.fill('mec-')
     // After typing, the filter is applied (table still rendered)

--- a/tests/integration/test-dashboard.bats
+++ b/tests/integration/test-dashboard.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# ============================================================================
+# Integration tests for mec dashboard subcommand
+#
+# These tests exercise the real Docker container lifecycle: start, stop,
+# status, and restart. They require Docker to be available and the dashboard
+# image to be present (pulled or built locally).
+#
+# Run conditions: same as other integration tests — push to main, releases,
+# and workflow_dispatch (see .github/workflows/test.yml).
+# ============================================================================
+
+BASEDIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+MEC="$BASEDIR/bin/mec"
+CONTAINER="mec-dashboard"
+
+setup() {
+    if ! docker info >/dev/null 2>&1; then
+        skip "Docker not available"
+    fi
+
+    export MEC_BASE_DIR="$BASEDIR"
+
+    TEST_CONFIG_DIR=$(mktemp -d)
+    export CONFIG_DIR="$TEST_CONFIG_DIR"
+    export CONFIG_FILE="$TEST_CONFIG_DIR/config.yaml"
+    export DEFAULT_CONFIG="$BASEDIR/config/config.default.yaml"
+
+    # Use a non-default port so tests don't collide with a user's running dashboard
+    export TEST_DASHBOARD_PORT=14242
+    echo "ai:"               > "$CONFIG_FILE"
+    echo "  dashboard:"     >> "$CONFIG_FILE"
+    echo "  port: $TEST_DASHBOARD_PORT" >> "$CONFIG_FILE"
+
+    # Ensure no leftover container from a previous failed run
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+}
+
+teardown() {
+    # Always clean up the container, even on test failure
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    [ -n "$TEST_CONFIG_DIR" ] && rm -rf "$TEST_CONFIG_DIR"
+}
+
+_image_available() {
+    # Returns 0 if the dashboard image exists locally
+    source "$BASEDIR/bin/utils/common.sh" 2>/dev/null || true
+    local img="${MEC_IMAGE_DASHBOARD:-davidcardoso/my-ez-cli:dashboard-latest}"
+    docker image inspect "$img" >/dev/null 2>&1
+}
+
+# ============================================================================
+# mec dashboard status — no container running
+# ============================================================================
+
+@test "mec dashboard status reports not running when no container exists" {
+    run "$MEC" dashboard status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "not running" ]]
+}
+
+# ============================================================================
+# mec dashboard stop — no-op when container absent
+# ============================================================================
+
+@test "mec dashboard stop is a no-op when container is not running" {
+    run "$MEC" dashboard stop
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "not running" ]]
+}
+
+# ============================================================================
+# mec dashboard start / stop / status lifecycle
+# ============================================================================
+
+@test "mec dashboard start launches container successfully" {
+    if ! _image_available; then
+        skip "Dashboard image not present locally"
+    fi
+    run "$MEC" dashboard start
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Dashboard started" ]]
+    # Container must actually be running
+    local state
+    state=$(docker inspect --format '{{.State.Status}}' "$CONTAINER" 2>/dev/null)
+    [ "$state" = "running" ]
+}
+
+@test "mec dashboard start prints UI and API URLs" {
+    if ! _image_available; then
+        skip "Dashboard image not present locally"
+    fi
+    run "$MEC" dashboard start
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "http://localhost:" ]]
+    [[ "$output" =~ "/api" ]]
+}
+
+@test "mec dashboard start is idempotent when already running" {
+    if ! _image_available; then
+        skip "Dashboard image not present locally"
+    fi
+    "$MEC" dashboard start >/dev/null
+    run "$MEC" dashboard start
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "already running" ]]
+}
+
+@test "mec dashboard status shows running after start" {
+    if ! _image_available; then
+        skip "Dashboard image not present locally"
+    fi
+    "$MEC" dashboard start >/dev/null
+    run "$MEC" dashboard status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "running" ]]
+}
+
+@test "mec dashboard stop removes running container" {
+    if ! _image_available; then
+        skip "Dashboard image not present locally"
+    fi
+    "$MEC" dashboard start >/dev/null
+    run "$MEC" dashboard stop
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "stopped" ]]
+    # Container must be gone
+    run docker inspect "$CONTAINER"
+    [ "$status" -ne 0 ]
+}
+
+@test "mec dashboard status shows not running after stop" {
+    if ! _image_available; then
+        skip "Dashboard image not present locally"
+    fi
+    "$MEC" dashboard start >/dev/null
+    "$MEC" dashboard stop  >/dev/null
+    run "$MEC" dashboard status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "not running" ]]
+}
+
+# ============================================================================
+# mec dashboard restart
+# ============================================================================
+
+@test "mec dashboard restart starts the container when it was stopped" {
+    if ! _image_available; then
+        skip "Dashboard image not present locally"
+    fi
+    # Start then stop so there's a clean stopped state
+    "$MEC" dashboard start >/dev/null
+    "$MEC" dashboard stop  >/dev/null
+    run "$MEC" dashboard restart
+    [ "$status" -eq 0 ]
+    local state
+    state=$(docker inspect --format '{{.State.Status}}' "$CONTAINER" 2>/dev/null)
+    [ "$state" = "running" ]
+}
+
+@test "mec dashboard restart replaces a running container" {
+    if ! _image_available; then
+        skip "Dashboard image not present locally"
+    fi
+    "$MEC" dashboard start >/dev/null
+    run "$MEC" dashboard restart
+    [ "$status" -eq 0 ]
+    local state
+    state=$(docker inspect --format '{{.State.Status}}' "$CONTAINER" 2>/dev/null)
+    [ "$state" = "running" ]
+}

--- a/tests/unit/test-dashboard.bats
+++ b/tests/unit/test-dashboard.bats
@@ -1,6 +1,12 @@
 #!/usr/bin/env bats
 # ============================================================================
-# Tests for mec dashboard subcommand (rebuild and restart --rebuild)
+# Unit tests for mec dashboard subcommand
+#
+# These tests verify structure, help output, static code properties, and
+# guard logic that does not require Docker or a live container.
+#
+# Real container lifecycle tests (start/stop/status/restart) live in:
+#   tests/integration/test-dashboard.bats
 # ============================================================================
 
 BASEDIR="$(cd "$(dirname "$BATS_TEST_DIRNAME")/.." && pwd)"
@@ -24,11 +30,34 @@ teardown() {
 }
 
 # ============================================================================
-# Help
+# Structure
 # ============================================================================
 
 @test "bin/mec has mec_dashboard function" {
     grep -q 'mec_dashboard' "$BASEDIR/bin/mec"
+}
+
+@test "mec_dashboard container name constant is defined" {
+    grep -q 'MEC_DASHBOARD_CONTAINER=' "$BASEDIR/bin/mec"
+}
+
+@test "mec dashboard dispatcher wires all subcommands" {
+    grep -q 'start)'   "$BASEDIR/bin/mec"
+    grep -q 'stop)'    "$BASEDIR/bin/mec"
+    grep -q 'restart)' "$BASEDIR/bin/mec"
+    grep -q 'rebuild)' "$BASEDIR/bin/mec"
+    grep -q 'status)'  "$BASEDIR/bin/mec"
+    grep -q 'open)'    "$BASEDIR/bin/mec"
+}
+
+# ============================================================================
+# Help
+# ============================================================================
+
+@test "mec dashboard with no args prints usage" {
+    run "$BASEDIR/bin/mec" dashboard
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage: mec dashboard" ]]
 }
 
 @test "mec dashboard help prints usage" {
@@ -43,16 +72,21 @@ teardown() {
     [[ "$output" =~ "Usage: mec dashboard" ]]
 }
 
-@test "mec dashboard help lists rebuild subcommand" {
-    run "$BASEDIR/bin/mec" dashboard help
+@test "mec dashboard -h prints usage" {
+    run "$BASEDIR/bin/mec" dashboard -h
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "rebuild" ]]
+    [[ "$output" =~ "Usage: mec dashboard" ]]
 }
 
-@test "mec dashboard help lists restart subcommand" {
+@test "mec dashboard help lists all subcommands" {
     run "$BASEDIR/bin/mec" dashboard help
     [ "$status" -eq 0 ]
+    [[ "$output" =~ "start"   ]]
+    [[ "$output" =~ "stop"    ]]
     [[ "$output" =~ "restart" ]]
+    [[ "$output" =~ "rebuild" ]]
+    [[ "$output" =~ "status"  ]]
+    [[ "$output" =~ "open"    ]]
 }
 
 @test "mec dashboard help mentions --rebuild flag for restart" {
@@ -61,59 +95,116 @@ teardown() {
     [[ "$output" =~ "--rebuild" ]]
 }
 
+@test "mec dashboard help mentions default port 4242" {
+    run "$BASEDIR/bin/mec" dashboard help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "4242" ]]
+}
+
 @test "mec dashboard unknown subcommand exits non-zero" {
     run "$BASEDIR/bin/mec" dashboard badcmd
     [ "$status" -ne 0 ]
+    [[ "$output" =~ "Unknown dashboard command" ]]
+}
+
+@test "mec dashboard unknown subcommand suggests help" {
+    run "$BASEDIR/bin/mec" dashboard badcmd
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "mec dashboard help" ]]
 }
 
 # ============================================================================
-# mec dashboard rebuild — no Docker required
+# Port configuration
 # ============================================================================
 
-@test "mec dashboard rebuild fails with clear error when Dockerfile is missing" {
-    # Verify the guard logic in bin/mec: rebuild must error when Dockerfile absent.
-    # We test the code path by grepping for the guard rather than running Docker.
-    grep -q 'Dockerfile not found' "$BASEDIR/bin/mec"
+@test "mec dashboard default port 4242 is hardcoded as fallback" {
+    grep -q '"4242"' "$BASEDIR/bin/mec" || grep -q "'4242'" "$BASEDIR/bin/mec"
+}
+
+@test "mec dashboard config key for port is ai.dashboard.port" {
+    grep -q 'ai.dashboard.port' "$BASEDIR/bin/mec"
+}
+
+# ============================================================================
+# mec dashboard open — code-level checks
+# ============================================================================
+
+@test "mec dashboard open falls back to echo URL when no browser is found" {
+    # Verify the fallback else branch exists in the script
+    grep -q 'echo.*http://localhost' "$BASEDIR/bin/mec"
+}
+
+@test "mec dashboard open supports open command for macOS" {
+    grep -q 'command -v open' "$BASEDIR/bin/mec"
+}
+
+@test "mec dashboard open supports xdg-open for Linux" {
+    grep -q 'xdg-open' "$BASEDIR/bin/mec"
+}
+
+# ============================================================================
+# mec dashboard start — guard logic
+# ============================================================================
+
+@test "mec dashboard start guard message references docker pull" {
+    grep -q 'docker pull' "$BASEDIR/bin/mec"
+}
+
+@test "mec dashboard start guard exits non-zero when image absent (no Docker)" {
+    if docker info >/dev/null 2>&1; then
+        skip "Docker available"
+    fi
+    run "$BASEDIR/bin/mec" dashboard start
+    [ "$status" -ne 0 ]
+}
+
+@test "mec dashboard start already-running message is present in script" {
+    grep -q 'already running' "$BASEDIR/bin/mec"
+}
+
+# ============================================================================
+# mec dashboard stop — guard logic
+# ============================================================================
+
+@test "mec dashboard stop not-running message is present in script" {
+    grep -q 'not running' "$BASEDIR/bin/mec"
+}
+
+# ============================================================================
+# mec dashboard rebuild — guard logic
+# ============================================================================
+
+@test "mec dashboard rebuild guard checks for Dockerfile presence" {
     grep -q '! -f.*Dockerfile' "$BASEDIR/bin/mec"
+    grep -q 'Dockerfile not found' "$BASEDIR/bin/mec"
 }
 
-@test "mec dashboard rebuild subcommand is wired in mec dispatcher" {
-    grep -q '"rebuild"' "$BASEDIR/bin/mec" || grep -q 'rebuild)' "$BASEDIR/bin/mec"
-}
-
-# ============================================================================
-# mec dashboard rebuild — Docker required
-# ============================================================================
-
-@test "mec dashboard rebuild prints Building message before docker build" {
-    # Verify the output prefix is present in the script (Docker build itself is
-    # an integration concern covered by docker-build-dashboard.yml workflow)
-    grep -q '"Building' "$BASEDIR/bin/mec" || grep -q '"Building ' "$BASEDIR/bin/mec"
+@test "mec dashboard rebuild prints Building and Build complete messages" {
+    grep -q 'Building' "$BASEDIR/bin/mec"
     grep -q 'Build complete' "$BASEDIR/bin/mec"
 }
 
 # ============================================================================
-# mec dashboard restart --rebuild flag parsing
+# mec dashboard restart — flag parsing logic
 # ============================================================================
 
-@test "mec dashboard restart --rebuild flag is parsed without error (dry run via rebuild path)" {
-    # Verify flag-parsing logic: --rebuild triggers mec_dashboard "rebuild" call.
-    # Without Docker we can confirm the code path is reached by checking that
-    # the error is Dockerfile-not-found (rebuild ran) rather than unknown-flag.
+@test "mec dashboard restart --rebuild flag parsing logic is present in script" {
+    grep -q '_do_rebuild' "$BASEDIR/bin/mec"
+    grep -q '"--rebuild"' "$BASEDIR/bin/mec"
+}
+
+@test "mec dashboard restart --rebuild does not produce unknown-flag error (no Docker)" {
     if docker info >/dev/null 2>&1; then
-        skip "Docker available — this test targets no-Docker path only"
+        skip "Docker available — rebuild would actually run"
     fi
     run "$BASEDIR/bin/mec" dashboard restart --rebuild
-    # Should NOT produce "Unknown" or "unrecognized" flag error
     [[ ! "$output" =~ "Unknown" ]]
     [[ ! "$output" =~ "unrecognized" ]]
 }
 
-@test "mec dashboard restart without --rebuild does not trigger rebuild" {
-    # Confirm that restart without --rebuild does not mention "Building"
-    # when Docker is unavailable (rebuild would print "Building <image>")
+@test "mec dashboard restart without --rebuild does not trigger rebuild (no Docker)" {
     if docker info >/dev/null 2>&1; then
-        skip "Docker available — cannot isolate rebuild path"
+        skip "Docker available — cannot isolate rebuild output"
     fi
     run "$BASEDIR/bin/mec" dashboard restart
     [[ ! "$output" =~ "Building" ]]

--- a/tests/unit/test-dashboard.bats
+++ b/tests/unit/test-dashboard.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# ============================================================================
+# Tests for mec dashboard subcommand (rebuild and restart --rebuild)
+# ============================================================================
+
+BASEDIR="$(cd "$(dirname "$BATS_TEST_DIRNAME")/.." && pwd)"
+
+setup() {
+    export MEC_BASE_DIR="$BASEDIR"
+
+    TEST_CONFIG_DIR=$(mktemp -d)
+    export CONFIG_DIR="$TEST_CONFIG_DIR"
+    export CONFIG_FILE="$TEST_CONFIG_DIR/config.yaml"
+    export DEFAULT_CONFIG="$BASEDIR/config/config.default.yaml"
+
+    TEST_DATA_DIR=$(mktemp -d)
+    export MEC_DATA_DIR="$TEST_DATA_DIR"
+    export MEC_LOG_DIR="$TEST_DATA_DIR/logs"
+}
+
+teardown() {
+    [ -n "$TEST_CONFIG_DIR" ] && rm -rf "$TEST_CONFIG_DIR"
+    [ -n "$TEST_DATA_DIR" ] && rm -rf "$TEST_DATA_DIR"
+}
+
+# ============================================================================
+# Help
+# ============================================================================
+
+@test "bin/mec has mec_dashboard function" {
+    grep -q 'mec_dashboard' "$BASEDIR/bin/mec"
+}
+
+@test "mec dashboard help prints usage" {
+    run "$BASEDIR/bin/mec" dashboard help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage: mec dashboard" ]]
+}
+
+@test "mec dashboard --help prints usage" {
+    run "$BASEDIR/bin/mec" dashboard --help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage: mec dashboard" ]]
+}
+
+@test "mec dashboard help lists rebuild subcommand" {
+    run "$BASEDIR/bin/mec" dashboard help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "rebuild" ]]
+}
+
+@test "mec dashboard help lists restart subcommand" {
+    run "$BASEDIR/bin/mec" dashboard help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "restart" ]]
+}
+
+@test "mec dashboard help mentions --rebuild flag for restart" {
+    run "$BASEDIR/bin/mec" dashboard help
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "--rebuild" ]]
+}
+
+@test "mec dashboard unknown subcommand exits non-zero" {
+    run "$BASEDIR/bin/mec" dashboard badcmd
+    [ "$status" -ne 0 ]
+}
+
+# ============================================================================
+# mec dashboard rebuild — no Docker required
+# ============================================================================
+
+@test "mec dashboard rebuild fails with clear error when Dockerfile is missing" {
+    # Verify the guard logic in bin/mec: rebuild must error when Dockerfile absent.
+    # We test the code path by grepping for the guard rather than running Docker.
+    grep -q 'Dockerfile not found' "$BASEDIR/bin/mec"
+    grep -q '! -f.*Dockerfile' "$BASEDIR/bin/mec"
+}
+
+@test "mec dashboard rebuild subcommand is wired in mec dispatcher" {
+    grep -q '"rebuild"' "$BASEDIR/bin/mec" || grep -q 'rebuild)' "$BASEDIR/bin/mec"
+}
+
+# ============================================================================
+# mec dashboard rebuild — Docker required
+# ============================================================================
+
+@test "mec dashboard rebuild prints Building message before docker build" {
+    # Verify the output prefix is present in the script (Docker build itself is
+    # an integration concern covered by docker-build-dashboard.yml workflow)
+    grep -q '"Building' "$BASEDIR/bin/mec" || grep -q '"Building ' "$BASEDIR/bin/mec"
+    grep -q 'Build complete' "$BASEDIR/bin/mec"
+}
+
+# ============================================================================
+# mec dashboard restart --rebuild flag parsing
+# ============================================================================
+
+@test "mec dashboard restart --rebuild flag is parsed without error (dry run via rebuild path)" {
+    # Verify flag-parsing logic: --rebuild triggers mec_dashboard "rebuild" call.
+    # Without Docker we can confirm the code path is reached by checking that
+    # the error is Dockerfile-not-found (rebuild ran) rather than unknown-flag.
+    if docker info >/dev/null 2>&1; then
+        skip "Docker available — this test targets no-Docker path only"
+    fi
+    run "$BASEDIR/bin/mec" dashboard restart --rebuild
+    # Should NOT produce "Unknown" or "unrecognized" flag error
+    [[ ! "$output" =~ "Unknown" ]]
+    [[ ! "$output" =~ "unrecognized" ]]
+}
+
+@test "mec dashboard restart without --rebuild does not trigger rebuild" {
+    # Confirm that restart without --rebuild does not mention "Building"
+    # when Docker is unavailable (rebuild would print "Building <image>")
+    if docker info >/dev/null 2>&1; then
+        skip "Docker available — cannot isolate rebuild path"
+    fi
+    run "$BASEDIR/bin/mec" dashboard restart
+    [[ ! "$output" =~ "Building" ]]
+}


### PR DESCRIPTION
## Summary

- Add `mec dashboard rebuild` subcommand (builds Docker image locally from `docker/dashboard/Dockerfile`); add `--rebuild` flag to `mec dashboard restart` (stop → build → start)
- Fix NavBar lifecycle bug: `onUnmounted` was called inside `onMounted` (fired on mount, not destroy), causing the WebSocket refresh subscription to leak; move to setup scope; add 30s polling fallback so LogsStatus/AIStatus chips update within 30s even without file-system events
- Extend session text search to match `command` and `cwd` fields (not just `session_id`); update placeholder to "Search sessions…"

## Test plan

- [ ] `mec dashboard help` — shows `rebuild` in command list with `--rebuild` note on restart
- [ ] `mec dashboard rebuild` — builds image (requires Docker)
- [ ] `mec dashboard restart --rebuild` — stop + build + start
- [ ] Run `mec ai enable` in a terminal; within 30s the NavBar AI chip should update without page reload
- [ ] Open Sessions page, type a partial path from a known session's cwd — should filter results
- [ ] `cd services/dashboard/frontend && npm run test` — all 24 tests pass

## Notes

NavBar polling interval is 30s. WsStatus chip still gets instant push updates via the reactive `connected` ref (unchanged behavior).