### PR TITLE
fix(docs): correct default node version to v22 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ Multi-version support:
 
 ```shell
 node20 -v  # maintenance LTS
-node22 -v
-node24 -v  # default
+node22 -v  # default (LTS)
+node24 -v
 ```
 
 **Custom ports** — use `MEC_BIND_PORTS`:


### PR DESCRIPTION
## Summary

- `bin/node` defaults to `node:22-alpine` (confirmed in line 13 of the script and `.claude/settings.json`)
- README incorrectly showed `node24 -v  # default` in the multi-version example

## Test plan

- [ ] `grep "node22.*default" README.md` returns a match

🤖 Generated with [Claude Code](https://claude.com/claude-code)