### PR TITLE
fix(logs): remove unused .raw.log files and trim noisy env vars

### DIFF
--- a/bin/utils/common.sh
+++ b/bin/utils/common.sh
@@ -129,11 +129,9 @@ setup_logging() {
         # Export legacy variables for backward compatibility
         LOG_ENABLED="$LOG_SESSION_ENABLED"
         LOG_FILE="$LOG_JSON_FILE"
-        RAW_LOG_FILE="$LOG_RAW_FILE"
 
         export LOG_ENABLED
         export LOG_FILE
-        export RAW_LOG_FILE
     else
         # Fallback to simple logging
         LOG_DIR="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}/${TOOL_NAME}"
@@ -143,18 +141,15 @@ setup_logging() {
 
             TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
             LOG_FILE="${LOG_DIR}/${TIMESTAMP}.log"
-            RAW_LOG_FILE="${LOG_DIR}/${TIMESTAMP}.raw.log"
 
             LOG_ENABLED=true
         else
             LOG_ENABLED=false
             LOG_FILE=""
-            RAW_LOG_FILE=""
         fi
 
         export LOG_ENABLED
         export LOG_FILE
-        export RAW_LOG_FILE
     fi
 }
 

--- a/bin/utils/log-manager.sh
+++ b/bin/utils/log-manager.sh
@@ -70,7 +70,6 @@ log_session_init() {
 
     # Create log file paths
     JSON_LOG_FILE="${TOOL_LOG_DIR}/${LOG_TIMESTAMP}.json"
-    RAW_LOG_FILE="${TOOL_LOG_DIR}/${LOG_TIMESTAMP}.raw.log"
 
     # Export session variables
     export LOG_SESSION_ENABLED="true"
@@ -81,11 +80,9 @@ log_session_init() {
     export LOG_SESSION_START_TIME="$TIMESTAMP"
     export LOG_SESSION_CWD="$(pwd)"
     export LOG_JSON_FILE="$JSON_LOG_FILE"
-    export LOG_RAW_FILE="$RAW_LOG_FILE"
 
-    # Touch log files
+    # Touch log file
     touch "$JSON_LOG_FILE"
-    touch "$RAW_LOG_FILE"
 }
 
 # Generate session ID for a tool
@@ -94,18 +91,6 @@ get_session_id() {
     TOOL_NAME="${1:-unknown}"
     TIMESTAMP=$(date +%s)
     echo "mec-${TOOL_NAME}-${TIMESTAMP}"
-}
-
-# ----------------------------------------------------------------------------
-# Output Capture
-# ----------------------------------------------------------------------------
-
-# Write raw output to raw log file
-# Usage: log_raw_output "stdout content"
-log_raw_output() {
-    if [ "$LOG_SESSION_ENABLED" = "true" ] && [ -n "$LOG_RAW_FILE" ]; then
-        echo "$1" >> "$LOG_RAW_FILE"
-    fi
 }
 
 # ----------------------------------------------------------------------------
@@ -179,8 +164,11 @@ get_log_environment() {
     ENV_JSON="{"
     FIRST=true
 
-    # Collect MEC_* variables
-    for VAR in $(env | grep '^MEC_' | cut -d= -f1); do
+    # Logging-system internals — not useful for AI analysis of tool output
+    _LOG_SKIP="MEC_LOG_DIR|MEC_LOG_LEVEL|MEC_LOG_FORMAT|MEC_LOG_COMPRESSION_DAYS|MEC_LOG_RETENTION_DAYS|MEC_SAVE_LOGS"
+
+    # Collect MEC_* variables (excluding logging internals)
+    for VAR in $(env | grep '^MEC_' | cut -d= -f1 | grep -vE "$_LOG_SKIP"); do
         VALUE=$(eval echo \$$VAR)
         # Skip sensitive variables
         if echo "$VAR" | grep -qi "token\|key\|secret\|password"; then

--- a/tests/unit/test-common-utils.bats
+++ b/tests/unit/test-common-utils.bats
@@ -50,7 +50,6 @@ setup() {
     MEC_SAVE_LOGS=1 setup_logging "test-tool"
     [ "$LOG_ENABLED" = "true" ]
     [ -n "$LOG_FILE" ]
-    [ -n "$RAW_LOG_FILE" ]
 }
 
 @test "setup_logging respects disabled logging" {

--- a/tests/unit/test-log-manager.bats
+++ b/tests/unit/test-log-manager.bats
@@ -85,13 +85,12 @@ teardown() {
     [ "$LOG_SESSION_ENABLED" = "false" ]
 }
 
-@test "log_session_init creates log files" {
+@test "log_session_init creates JSON log file" {
     export MEC_LOGS_ENABLED="true"
 
     log_session_init "node" "node:24-alpine" "node server.js"
 
     [ -f "$LOG_JSON_FILE" ]
-    [ -f "$LOG_RAW_FILE" ]
 }
 
 # ----------------------------------------------------------------------------
@@ -148,6 +147,24 @@ teardown() {
 
     [[ "$ENV_JSON" =~ \[REDACTED\] ]]
     [[ ! "$ENV_JSON" =~ secret123 ]]
+}
+
+@test "get_log_environment excludes logging internals" {
+    export MEC_LOG_DIR="/tmp/test-logs"
+    export MEC_LOG_LEVEL="debug"
+    export MEC_LOG_FORMAT="json"
+    export MEC_LOG_COMPRESSION_DAYS="7"
+    export MEC_LOG_RETENTION_DAYS="30"
+    export MEC_SAVE_LOGS="1"
+
+    ENV_JSON=$(get_log_environment)
+
+    [[ ! "$ENV_JSON" =~ MEC_LOG_DIR ]]
+    [[ ! "$ENV_JSON" =~ MEC_LOG_LEVEL ]]
+    [[ ! "$ENV_JSON" =~ MEC_LOG_FORMAT ]]
+    [[ ! "$ENV_JSON" =~ MEC_LOG_COMPRESSION_DAYS ]]
+    [[ ! "$ENV_JSON" =~ MEC_LOG_RETENTION_DAYS ]]
+    [[ ! "$ENV_JSON" =~ MEC_SAVE_LOGS ]]
 }
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Remove `.raw.log` file creation — these files were always empty since AI analyses moved to `ai-analyses/`; the `.json` log is already the immutable record
- Remove `log_raw_output()` helper (unused)
- Remove `RAW_LOG_FILE` legacy compat shim in `common.sh`
- Filter logging-system internals (`MEC_LOG_DIR`, `MEC_LOG_LEVEL`, `MEC_LOG_FORMAT`, etc.) from `get_log_environment()` — these are not useful context for AI analysis and consumed extra tokens
- Update unit tests to reflect the changes

## Test plan

- [ ] `bats tests/unit/test-log-manager.bats` — all 23 tests pass
- [ ] Enable logging, run a tool, verify only `*.json` files created (no `*.raw.log`)
- [ ] Check log JSON `environment` field doesn't contain `MEC_LOG_DIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)