### PR TITLE
feat: introduce MEC_HOME env var for data directory (#76)

### DIFF
--- a/bin/mec
+++ b/bin/mec
@@ -291,7 +291,7 @@ mec_ai() {
             printf '%s\n' "  mec ai test"
             printf '%s\n' "  mec ai last"
             printf '%s\n' "  mec ai logs --last 5"
-            printf '%s\n' "  mec ai analyze ~/.my-ez-cli/logs/node/2026-01-01_12-00-00.json"
+            printf '%s\n' "  mec ai analyze \$MEC_HOME/logs/node/2026-01-01_12-00-00.json"
             printf '%s\n' "  mec config set ai.claude.model haiku"
             ;;
         *)
@@ -378,7 +378,7 @@ print(items[-1][0] if items else '', end='')
 # Show the most recent session: reads metadata from the log file (source of
 # truth) and the analysis result from the sidecar if available.
 _mec_ai_last() {
-    local log_dir="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}"
+    local log_dir="${MEC_LOG_DIR:-${MEC_HOME}/logs}"
 
     if [ ! -d "$log_dir" ]; then
         echo "No logs found (directory not created yet)."
@@ -405,7 +405,7 @@ _mec_ai_show() {
         return 1
     fi
 
-    local log_dir="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}"
+    local log_dir="${MEC_LOG_DIR:-${MEC_HOME}/logs}"
     local log_file
     log_file=$(grep -rl "\"session_id\".*\"${session_id}\"" "$log_dir" 2>/dev/null | grep -v "\.bak$" | grep "\.json$" | head -1)
 
@@ -436,7 +436,7 @@ _mec_ai_logs() {
         esac
     done
 
-    local log_dir="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}"
+    local log_dir="${MEC_LOG_DIR:-${MEC_HOME}/logs}"
 
     if [ ! -d "$log_dir" ]; then
         echo "No log directory found at $log_dir"
@@ -501,7 +501,7 @@ mec_logs() {
             local logging_enabled
             logging_enabled=$(config_get_default "logs.enabled" "false")
             echo "  Logging enabled: $logging_enabled"
-            local log_dir="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}"
+            local log_dir="${MEC_LOG_DIR:-${MEC_HOME}/logs}"
             echo "  Log directory:   $log_dir"
             if [ -d "$log_dir" ]; then
                 local count
@@ -514,7 +514,7 @@ mec_logs() {
         enable)
             config_set "logs.enabled" "true"
             echo "Logging enabled."
-            echo "Logs will be written to ${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}/"
+            echo "Logs will be written to ${MEC_LOG_DIR:-${MEC_HOME}/logs}/"
             ;;
         disable)
             config_set "logs.enabled" "false"
@@ -571,7 +571,7 @@ _ai_sidecar_exists() {
 }
 
 # _mec_logs_list [--tool <name>] [--last N]
-# List recent execution log entries from ~/.my-ez-cli/logs/
+# List recent execution log entries from $MEC_HOME/logs/
 _mec_logs_list() {
     local filter_tool=""
     local last_n=20
@@ -595,7 +595,7 @@ _mec_logs_list() {
         esac
     done
 
-    local log_dir="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}"
+    local log_dir="${MEC_LOG_DIR:-${MEC_HOME}/logs}"
 
     if [ ! -d "$log_dir" ]; then
         echo "No log directory found at $log_dir"
@@ -694,7 +694,7 @@ _mec_logs_failures() {
         esac
     done
 
-    local log_dir="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}"
+    local log_dir="${MEC_LOG_DIR:-${MEC_HOME}/logs}"
 
     if [ ! -d "$log_dir" ]; then
         echo "No log directory found at $log_dir"
@@ -769,7 +769,7 @@ except:
 # _mec_logs_stats
 # Show aggregate execution statistics
 _mec_logs_stats() {
-    local log_dir="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}"
+    local log_dir="${MEC_LOG_DIR:-${MEC_HOME}/logs}"
 
     if [ ! -d "$log_dir" ]; then
         echo "No log directory found at $log_dir"
@@ -1120,7 +1120,7 @@ mec_dashboard() {
                 --name "$MEC_DASHBOARD_CONTAINER" \
                 --restart unless-stopped \
                 -p "${dashboard_port}:4242" \
-                --volume "${HOME}/.my-ez-cli:/data:ro" \
+                --volume "${MEC_HOME}:/data:ro" \
                 "$MEC_IMAGE_DASHBOARD" >/dev/null
 
             echo "Dashboard started"
@@ -1296,7 +1296,7 @@ _mec_doctor_run() {
     # ------------------------------------------------------------------
     # 3. Data directory
     # ------------------------------------------------------------------
-    local data_dir="${MEC_DATA_DIR:-${HOME}/.my-ez-cli}"
+    local data_dir="${MEC_DATA_DIR:-${MEC_HOME}}"
     if [ ! -d "$data_dir" ]; then
         _doc_fail "Data directory: not found  (${data_dir} — run 'mec logs enable' to create)"
     elif [ ! -w "$data_dir" ]; then
@@ -1308,7 +1308,7 @@ _mec_doctor_run() {
     # ------------------------------------------------------------------
     # 4. Config file
     # ------------------------------------------------------------------
-    local config_file="${CONFIG_FILE:-${HOME}/.my-ez-cli/config.yaml}"
+    local config_file="${CONFIG_FILE:-${MEC_HOME}/config.yaml}"
     if [ -f "$config_file" ]; then
         _doc_pass "Config file: ${config_file}  (exists)"
     else
@@ -1451,7 +1451,7 @@ mec_purge() {
 
     case "$subcmd" in
         data)
-            local _data_dir="${MEC_DATA_DIR:-${HOME}/.my-ez-cli}"
+            local _data_dir="${MEC_DATA_DIR:-${MEC_HOME}}"
             local log_dir="${MEC_LOG_DIR:-${_data_dir}/logs}"
             local ai_dir="${_data_dir}/ai-analyses"
 
@@ -1518,8 +1518,8 @@ mec_purge() {
             printf '%s\n' "${_b}FLAGS${_r}"
             printf '%s\n' "  --tool <name>        Only purge files for a specific tool (e.g. node, aws)"
             printf '%s\n' "  --older-than <days>  Only purge files older than N days"
-            printf '%s\n' "  --only-logs          Only purge ~/.my-ez-cli/logs/"
-            printf '%s\n' "  --only-ai-analyses   Only purge ~/.my-ez-cli/ai-analyses/"
+            printf '%s\n' "  --only-logs          Only purge \$MEC_HOME/logs/"
+            printf '%s\n' "  --only-ai-analyses   Only purge \$MEC_HOME/ai-analyses/"
             printf '%s\n' "  --dry-run            Preview what would be deleted without deleting"
             printf '%s\n' "  -y, --yes            Skip confirmation prompts"
             printf '%s\n' ""

--- a/bin/utils/common.sh
+++ b/bin/utils/common.sh
@@ -9,6 +9,12 @@ set -e
 # ============================================================================
 
 # ----------------------------------------------------------------------------
+# Data Directory
+# ----------------------------------------------------------------------------
+MEC_HOME="${MEC_HOME:-${HOME}/.my-ez-cli}"
+export MEC_HOME
+
+# ----------------------------------------------------------------------------
 # Docker Image Constants
 # ----------------------------------------------------------------------------
 MEC_IMAGE_REPO="${MEC_IMAGE_REPO:-davidcardoso/my-ez-cli}"
@@ -134,7 +140,7 @@ setup_logging() {
         export LOG_FILE
     else
         # Fallback to simple logging
-        LOG_DIR="${MEC_LOG_DIR:-${HOME}/.my-ez-cli/logs}/${TOOL_NAME}"
+        LOG_DIR="${MEC_LOG_DIR:-${MEC_HOME}/logs}/${TOOL_NAME}"
 
         if [ "$MEC_SAVE_LOGS" = "1" ] || [ "${MEC_LOGS_ENABLED:-false}" = "true" ]; then
             mkdir -p "$LOG_DIR"
@@ -285,7 +291,7 @@ analyze_with_claude() {
     local dashboard_port
     dashboard_port=$(config_get_default "ai.dashboard.port" "4242")
 
-    # Compute sidecar path: ~/.my-ez-cli/logs/tool/ts.json -> ~/.my-ez-cli/ai-analyses/tool/ts.json
+    # Compute sidecar path: $MEC_HOME/logs/tool/ts.json -> $MEC_HOME/ai-analyses/tool/ts.json
     local log_dir
     log_dir=$(dirname "$log_file")
     local ai_analyses_dir

--- a/bin/utils/config-manager.sh
+++ b/bin/utils/config-manager.sh
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 # Constants
 # ----------------------------------------------------------------------------
-CONFIG_DIR="${HOME}/.my-ez-cli"
+CONFIG_DIR="${MEC_HOME:-${HOME}/.my-ez-cli}"
 CONFIG_FILE="${CONFIG_DIR}/config.yaml"
 DEFAULT_CONFIG="${MEC_BASE_DIR:-$(dirname "$0")}/config/config.default.yaml"
 

--- a/bin/utils/log-manager.sh
+++ b/bin/utils/log-manager.sh
@@ -10,8 +10,8 @@
 # Constants
 # ----------------------------------------------------------------------------
 LOG_FORMAT_VERSION="1.0"
-DEFAULT_LOG_DIR="${HOME}/.my-ez-cli/logs"
-DEFAULT_CONFIG_FILE="${HOME}/.my-ez-cli/config.yaml"
+DEFAULT_LOG_DIR="${MEC_HOME:-${HOME}/.my-ez-cli}/logs"
+DEFAULT_CONFIG_FILE="${MEC_HOME:-${HOME}/.my-ez-cli}/config.yaml"
 
 # ----------------------------------------------------------------------------
 # Configuration


### PR DESCRIPTION
## Summary

Replaces all hardcoded `~/.my-ez-cli/` references with `${MEC_HOME}`, introduced in `bin/utils/common.sh` and exported to all sourced utilities.

Closes #76

## Changes

- `bin/utils/common.sh` — define `MEC_HOME="${MEC_HOME:-${HOME}/.my-ez-cli}"` and export at top of file
- `bin/utils/log-manager.sh` — `DEFAULT_LOG_DIR` and `DEFAULT_CONFIG_FILE` derive from `MEC_HOME`
- `bin/utils/config-manager.sh` — `CONFIG_DIR` defaults to `MEC_HOME`
- `bin/mec` — all `log_dir` / `data_dir` / dashboard volume mount references use `MEC_HOME`; help text shows `$MEC_HOME` instead of literal path

## Backward compatibility

- `MEC_HOME` defaults to `${HOME}/.my-ez-cli` — no behavior change for existing users
- Existing `MEC_LOG_DIR` and `MEC_DATA_DIR` overrides still work; they now fall back to `${MEC_HOME}/logs` and `${MEC_HOME}` respectively instead of hardcoded paths
- `CONFIG_FILE` override still respected in `mec doctor`

## Test plan

- [x] `bats tests/unit/test-common-utils.bats` — 10/10 pass
- [x] `bats tests/unit/test-doctor.bats` — 14/14 pass
- [x] `MEC_HOME=/tmp/custom ./bin/mec doctor` — shows `/tmp/custom` as data/config paths
- [x] `./bin/mec ai --help` — shows `$MEC_HOME/logs/...` in example
- [x] `./bin/mec purge --help` — shows `$MEC_HOME/logs/` and `$MEC_HOME/ai-analyses/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)