### PR TITLE
feat: dispatch all tool wrappers as mec subcommands (#74)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,13 @@ jobs:
           ./bin/mec dashboard help | grep -q 'rebuild'
           echo "✓ mec dashboard rebuild documented in help"
 
+      - name: Test mec tool subcommand dispatch
+        run: |
+          ./bin/mec help | grep -q 'TOOLS'
+          echo "✓ mec help lists TOOLS section"
+          ./bin/mec unknown-tool 2>&1 | grep -q 'Unknown command'
+          echo "✓ mec unknown-tool returns error"
+
   # Unit tests - run in parallel for faster execution
   unit-tests:
     runs-on: ubuntu-latest

--- a/bin/mec
+++ b/bin/mec
@@ -73,6 +73,27 @@ show_help() {
     printf '%s\n' "  claude              Run Claude Code interactively"
     printf '%s\n' "  claude firewall *   Manage Claude Code container firewall"
     printf '%s\n' ""
+    printf '%s\n' "${_b}TOOLS${_r}"
+    printf '%s\n' "  aws                 AWS CLI"
+    printf '%s\n' "  aws-get-session-token  AWS session token helper"
+    printf '%s\n' "  aws-sso             AWS SSO login"
+    printf '%s\n' "  aws-sso-cred        AWS SSO credential provider"
+    printf '%s\n' "  gcloud              Google Cloud CLI"
+    printf '%s\n' "  gcloud-login        Google Cloud interactive login"
+    printf '%s\n' "  node, node20/22/24  Node.js (default: node22)"
+    printf '%s\n' "  npm, npm20/22       npm"
+    printf '%s\n' "  npx, npx20/22       npx"
+    printf '%s\n' "  playwright          Playwright browser testing"
+    printf '%s\n' "  promptfoo           PromptFoo AI evaluation"
+    printf '%s\n' "  promptfoo-server    PromptFoo server"
+    printf '%s\n' "  python              Python"
+    printf '%s\n' "  serverless          Serverless Framework"
+    printf '%s\n' "  speedtest           Network speed test"
+    printf '%s\n' "  terraform           Terraform"
+    printf '%s\n' "  yarn, yarn20/22     Yarn"
+    printf '%s\n' "  yarn-berry          Yarn Berry (v2+)"
+    printf '%s\n' "  yarn-plus           Yarn with git, curl, jq"
+    printf '%s\n' ""
     printf '%s\n' "${_b}OTHER COMMANDS${_r}"
     printf '%s\n' "  version             Show version"
     printf '%s\n' "  help                Show this help"
@@ -81,6 +102,8 @@ show_help() {
     printf '%s\n' ""
     printf '%s\n' "${_b}EXAMPLES${_r}"
     printf '%s\n' "  mec install node terraform"
+    printf '%s\n' "  mec node --version"
+    printf '%s\n' "  mec terraform --version"
     printf '%s\n' "  mec ai status"
     printf '%s\n' "  mec dashboard start"
     printf '%s\n' "  mec logs list --tool node"
@@ -1597,6 +1620,21 @@ case "$COMMAND" in
         ;;
     help|--help|-h)
         show_help
+        ;;
+    # Tool wrappers — delegate directly to the corresponding bin/ script
+    aws|aws-get-session-token|aws-sso|aws-sso-cred| \
+    gcloud|gcloud-login| \
+    node|node20|node22|node24| \
+    npm|npm20|npm22| \
+    npx|npx20|npx22| \
+    playwright| \
+    promptfoo|promptfoo-server| \
+    python| \
+    serverless| \
+    speedtest| \
+    terraform| \
+    yarn|yarn-berry|yarn-plus|yarn20|yarn22)
+        exec "$SCRIPT_DIR/$COMMAND" "${@:2}"
         ;;
     *)
         echo "Unknown command: $COMMAND" >&2


### PR DESCRIPTION
## Summary

Like `mec claude`, all 28 tool wrappers in `bin/` are now invocable as `mec <tool>` subcommands. Arguments and flags pass through unchanged via `exec`.

Closes #74

## Changes

- `bin/mec` — new case block delegates all tool names to `exec "$SCRIPT_DIR/$COMMAND" "${@:2}"`; `show_help` updated with a TOOLS section
- `.github/workflows/test.yml` — smoke test verifies TOOLS section presence and unknown-command error

## Tools added

`aws`, `aws-get-session-token`, `aws-sso`, `aws-sso-cred`, `gcloud`, `gcloud-login`, `node`, `node20/22/24`, `npm`, `npm20/22`, `npx`, `npx20/22`, `playwright`, `promptfoo`, `promptfoo-server`, `python`, `serverless`, `speedtest`, `terraform`, `yarn`, `yarn-berry`, `yarn-plus`, `yarn20/22`

(`claude` already existed and is unchanged.)

## Test plan

- [x] `./bin/mec help` — shows TOOLS section with all tools listed
- [x] `./bin/mec node --help` — delegates to `bin/node`
- [x] `./bin/mec terraform --help` — delegates to `bin/terraform`
- [x] `./bin/mec unknown-tool` — returns "Unknown command" error
- [x] `bats tests/unit/` — 222/222 pass
- [x] CI smoke test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)