### PR TITLE
feat: mec setup/install output styling — colors, bold, ASCII icons (#78)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,6 +180,11 @@ jobs:
           ./setup.sh status | grep -q 'Installation Status'
           echo "✓ setup.sh status shows installation status header"
 
+      - name: Test mec setup status subcommand
+        run: |
+          ./bin/mec setup status | grep -q 'Installation Status'
+          echo "✓ mec setup status works"
+
   # Unit tests - run in parallel for faster execution
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,16 @@ jobs:
           ./bin/mec unknown-tool 2>&1 | grep -q 'Unknown command'
           echo "✓ mec unknown-tool returns error"
 
+      - name: Test mec install error output
+        run: |
+          ./bin/mec install 2>&1 | grep -q 'install'
+          echo "✓ mec install error contains usage text"
+
+      - name: Test setup.sh status output
+        run: |
+          ./setup.sh status | grep -q 'Installation Status'
+          echo "✓ setup.sh status shows installation status header"
+
   # Unit tests - run in parallel for faster execution
   unit-tests:
     runs-on: ubuntu-latest

--- a/bin/mec
+++ b/bin/mec
@@ -110,15 +110,6 @@ show_help() {
     printf '%s\n' "  mec claude firewall status"
 }
 
-# _mec_err "message" — print styled error to stderr
-_mec_err() {
-    local _re="" _rr=""
-    if [ -t 2 ]; then
-        _re=$(printf '\033[0;31m')
-        _rr=$(printf '\033[0m')
-    fi
-    printf '%s\n' "${_re}✗${_rr} ${1}" >&2
-}
 
 # ----------------------------------------------------------------------------
 # AI Commands
@@ -1105,7 +1096,7 @@ EOF
 
 mec_install() {
     if [ $# -eq 0 ]; then
-        _mec_err "Usage: mec install <tool> [tool2 ...]"
+        msg_err "Usage: mec install <tool> [tool2 ...]"
         return 1
     fi
     exec "${BASE_DIR}/setup.sh" install "$@"
@@ -1113,7 +1104,7 @@ mec_install() {
 
 mec_uninstall() {
     if [ $# -eq 0 ]; then
-        _mec_err "Usage: mec uninstall <tool> [tool2 ...]"
+        msg_err "Usage: mec uninstall <tool> [tool2 ...]"
         return 1
     fi
     exec "${BASE_DIR}/setup.sh" uninstall "$@"

--- a/bin/mec
+++ b/bin/mec
@@ -1078,7 +1078,7 @@ mec_setup() {
         "")
             exec "${BASE_DIR}/setup.sh"
             ;;
-        show)
+        status|show)
             exec "${BASE_DIR}/setup.sh" status
             ;;
         help|--help|-h)
@@ -1086,13 +1086,13 @@ mec_setup() {
 Usage: mec setup [subcommand]
 
 Subcommands:
-  (none)   Open interactive setup TUI
-  show     Show installation status
-  help     Show this help message
+  (none)    Open interactive setup TUI
+  status    Show installation status
+  help      Show this help message
 
 Examples:
   mec setup
-  mec setup show
+  mec setup status
 EOF
             ;;
         *)

--- a/bin/mec
+++ b/bin/mec
@@ -110,6 +110,16 @@ show_help() {
     printf '%s\n' "  mec claude firewall status"
 }
 
+# _mec_err "message" — print styled error to stderr
+_mec_err() {
+    local _re="" _rr=""
+    if [ -t 2 ]; then
+        _re=$(printf '\033[0;31m')
+        _rr=$(printf '\033[0m')
+    fi
+    printf '%s\n' "${_re}✗${_rr} ${1}" >&2
+}
+
 # ----------------------------------------------------------------------------
 # AI Commands
 # ----------------------------------------------------------------------------
@@ -1095,7 +1105,7 @@ EOF
 
 mec_install() {
     if [ $# -eq 0 ]; then
-        echo "Usage: mec install <tool> [tool2 ...]" >&2
+        _mec_err "Usage: mec install <tool> [tool2 ...]"
         return 1
     fi
     exec "${BASE_DIR}/setup.sh" install "$@"
@@ -1103,7 +1113,7 @@ mec_install() {
 
 mec_uninstall() {
     if [ $# -eq 0 ]; then
-        echo "Usage: mec uninstall <tool> [tool2 ...]" >&2
+        _mec_err "Usage: mec uninstall <tool> [tool2 ...]"
         return 1
     fi
     exec "${BASE_DIR}/setup.sh" uninstall "$@"

--- a/bin/utils/common.sh
+++ b/bin/utils/common.sh
@@ -36,6 +36,39 @@ export MEC_IMAGE_SPEEDTEST MEC_IMAGE_AWS_SSO_CRED MEC_IMAGE_YARN_BERRY MEC_IMAGE
 export MEC_IMAGE_DASHBOARD
 
 # ----------------------------------------------------------------------------
+# Output helpers — TTY-safe color/icon output
+# ----------------------------------------------------------------------------
+# Set ANSI codes only when stdout is a terminal
+_G="" _Y="" _R="" _B="" _RST=""
+if [ -t 1 ]; then
+    _G=$(printf '\033[0;32m')   # green
+    _Y=$(printf '\033[0;33m')   # yellow
+    _R=$(printf '\033[0;31m')   # red
+    _B=$(printf '\033[1m')      # bold
+    _RST=$(printf '\033[0m')    # reset
+fi
+
+# msg_ok "message"   — green ✓  (success)
+msg_ok() {
+    printf '%s\n' "${_G}✓${_RST} ${1}"
+}
+
+# msg_warn "message" — yellow ⚠  (non-fatal warning, writes to stderr)
+msg_warn() {
+    printf '%s\n' "${_Y}⚠${_RST} ${1}" >&2
+}
+
+# msg_err "message"  — red ✗  (error, writes to stderr)
+msg_err() {
+    printf '%s\n' "${_R}✗${_RST} ${1}" >&2
+}
+
+# msg_info "message" — bold →  (informational note)
+msg_info() {
+    printf '%s\n' "${_B}→${_RST} ${1}"
+}
+
+# ----------------------------------------------------------------------------
 # Path Resolution (works with symlinks)
 # ----------------------------------------------------------------------------
 # Resolves the real path of the script, following symlinks

--- a/setup.sh
+++ b/setup.sh
@@ -9,12 +9,42 @@ mkdir -p "$HOME/.my-ez-cli"
 
 # Helpers
 
+# ---------------------------------------------------------------------------
+# Output helpers — TTY-safe color/icon output
+# ---------------------------------------------------------------------------
+# Set ANSI codes only when stdout is a terminal
+_G="" _Y="" _R="" _B="" _RST=""
+if [ -t 1 ]; then
+    _G=$(printf '\033[0;32m')   # green
+    _Y=$(printf '\033[0;33m')   # yellow
+    _R=$(printf '\033[0;31m')   # red
+    _B=$(printf '\033[1m')      # bold
+    _RST=$(printf '\033[0m')    # reset
+fi
+
+# msg_ok "message"   — green ✓  (success)
+msg_ok() {
+    printf '%s\n' "${_G}✓${_RST} ${1}"
+}
+
+# msg_warn "message" — yellow ⚠  (non-fatal warning or side-by-side notice)
+msg_warn() {
+    printf '%s\n' "${_Y}⚠${_RST} ${1}" >&2
+}
+
+# msg_err "message"  — red ✗  (fatal error, writes to stderr)
+msg_err() {
+    printf '%s\n' "${_R}✗${_RST} ${1}" >&2
+}
+
+# msg_info "message" — bold →  (informational note)
+msg_info() {
+    printf '%s\n' "${_B}→${_RST} ${1}"
+}
+
+# show_msg kept as alias to msg_ok for backward compatibility during migration
 show_msg() {
-    cat <<EOF
---------------------------------------------------------------------------------
-$1
---------------------------------------------------------------------------------
-EOF
+    msg_ok "${1}"
 }
 
 show_help() {

--- a/setup.sh
+++ b/setup.sh
@@ -1130,7 +1130,7 @@ show_status() {
                 verified_label="${_G}✓${_RST}"
             else
                 status_label="${_Y}Installed${_RST}"
-                verified_label="${_Y}✗${_RST}"
+                verified_label="${_R}✗${_RST}"
             fi
         else
             status_label="Not Installed"

--- a/setup.sh
+++ b/setup.sh
@@ -83,22 +83,18 @@ EOF
 }
 
 show_begin() {
-    cat <<EOF
---------------------------------------------------------------------------------
-                  My Ez CLI • Setup
---------------------------------------------------------------------------------
-  Hope you enjoy it! :D
---------------------------------------------------------------------------------
-  Note: Aliases may be created in '~/.zshrc' file...
---------------------------------------------------------------------------------
-  Note: Symbolic links may be created in '/usr/local/bin/' folder...
---------------------------------------------------------------------------------
-  Warning: Root access may be needed.
---------------------------------------------------------------------------------
-  GitHub: https://github.com/DavidCardoso/my-ez-cli
---------------------------------------------------------------------------------
-
-EOF
+    printf '%s\n' "${_B}--------------------------------------------------------------------------------${_RST}"
+    printf '%s\n' "${_B}                  My Ez CLI • Setup${_RST}"
+    printf '%s\n' "${_B}--------------------------------------------------------------------------------${_RST}"
+    printf '%s\n' "  Hope you enjoy it! :D"
+    printf '%s\n' ""
+    printf '%s\n' "  ${_Y}⚠${_RST}  Aliases may be created in '~/.zshrc'"
+    printf '%s\n' "  ${_Y}⚠${_RST}  Symbolic links may be created in '/usr/local/bin/'"
+    printf '%s\n' "  ${_Y}⚠${_RST}  Root access may be needed"
+    printf '%s\n' ""
+    printf '%s\n' "  GitHub: https://github.com/DavidCardoso/my-ez-cli"
+    printf '%s\n' "${_B}--------------------------------------------------------------------------------${_RST}"
+    printf '%s\n' ""
 }
 
 # Tracking functions
@@ -1126,19 +1122,24 @@ show_status() {
     echo "--------------------------------------------------------------------------------"
 
     for tool in "${tools[@]}"; do
-        local status="Not Installed"
-        local verified=""
+        local status_label="" verified_label=""
 
         if is_tracked "$tool"; then
-            status="Installed"
             if verify_installation "$tool" 2>/dev/null; then
-                verified="✓"
+                status_label="${_G}Installed${_RST}"
+                verified_label="${_G}✓${_RST}"
             else
-                verified="✗"
+                status_label="${_Y}Installed${_RST}"
+                verified_label="${_Y}✗${_RST}"
             fi
+        else
+            status_label="Not Installed"
         fi
 
-        printf "%-20s  %-13s %-10s\n" "$tool" "$status" "$verified"
+        # Add ANSI byte lengths to column widths so printf pads correctly
+        local ansi_len=$(( ${#_G} + ${#_RST} ))
+        printf "%-20s  %-$((13 + ansi_len))s %-$((10 + ansi_len))s\n" \
+            "$tool" "$status_label" "$verified_label"
     done
 
     echo "================================================================================
@@ -1148,15 +1149,15 @@ show_status() {
 # Interactive multi-select menu - Terminal-based
 
 interactive_menu() {
-    echo "================================================================================
-                  My Ez CLI • Interactive Setup
-================================================================================
-
-Select tools to install/uninstall (enter tool numbers separated by spaces)
-or type 'all' to install all tools, 'done' when finished.
-
-Available tools:"
-    echo "--------------------------------------------------------------------------------"
+    printf '%s\n' "${_B}================================================================================${_RST}"
+    printf '%s\n' "${_B}                  My Ez CLI • Interactive Setup${_RST}"
+    printf '%s\n' "${_B}================================================================================${_RST}"
+    printf '%s\n' ""
+    printf '%s\n' "Select tools to install/uninstall (enter tool numbers separated by spaces)"
+    printf '%s\n' "or type 'all' to install all tools, 'done' when finished."
+    printf '%s\n' ""
+    printf '%s\n' "Available tools:"
+    printf '%s\n' "--------------------------------------------------------------------------------"
 
     local tools=("mec" "aws" "node" "npm" "npx" "yarn" "yarn-plus" "yarn-berry" "serverless" "terraform" "speedtest" "gcloud" "playwright" "python" "promptfoo" "promptfoo-server" "claude")
     local descriptions=("My Ez CLI command" "AWS CLI and SSO tools" "Node.js (v22, v24 LTS)" "NPM package manager" "NPX package runner" "Yarn package manager" "Yarn + git/curl/jq tools" "Yarn Berry (v2+)" "Serverless Framework" "Terraform CLI" "Ookla Speedtest CLI" "Google Cloud CLI" "Playwright testing" "Python interpreter" "Promptfoo evaluation" "Promptfoo server" "Claude Code CLI")
@@ -1165,7 +1166,7 @@ Available tools:"
     for tool in "${tools[@]}"; do
         local status="  "
         if is_tracked "$tool"; then
-            status="✓ "
+            status="${_G}✓${_RST}"
         fi
         printf "%2d. [%s] %-20s - %s\n" "$i" "$status" "$tool" "${descriptions[$((i-1))]}"
         ((i++))

--- a/setup.sh
+++ b/setup.sh
@@ -140,11 +140,11 @@ verify_symlink() {
         if [ -f "$target" ]; then
             return 0
         else
-            echo "Warning: Broken symlink for $tool_name (target: $target)"
+            msg_warn "Broken symlink for $tool_name (target: $target)"
             return 1
         fi
     else
-        echo "Warning: $tool_name not found at $link_path"
+        msg_warn "$tool_name not found at $link_path"
         return 1
     fi
 }
@@ -189,16 +189,16 @@ install_aws() {
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
         sudo ln -sf ${BASEDIR}/bin/aws /usr/local/bin/aws
-        show_msg "Activating aws..."
+        msg_ok "Activating aws"
 
         echo "alias aws-get-session-token=\"${BASEDIR}/bin/aws-get-session-token \"" >>~/.zshrc
-        show_msg "Activating aws-get-session-token..."
+        msg_ok "Activating aws-get-session-token"
 
         echo "alias aws-sso=\"${BASEDIR}/bin/aws-sso \"" >>~/.zshrc
-        show_msg "Activating aws-sso..."
+        msg_ok "Activating aws-sso"
 
         sudo ln -sf ${BASEDIR}/bin/aws-sso-cred /usr/local/bin/aws-sso-cred
-        show_msg "Activating aws-sso-cred..."
+        msg_ok "Activating aws-sso-cred"
     else
         local existing_path="${detected#external:}"
         handle_tool_conflict "aws" "$existing_path"
@@ -206,19 +206,19 @@ install_aws() {
         if [[ $result -eq 0 ]]; then
             # Replace
             sudo ln -sf ${BASEDIR}/bin/aws /usr/local/bin/aws
-            show_msg "Activating aws..."
+            msg_ok "Activating aws"
 
             echo "alias aws-get-session-token=\"${BASEDIR}/bin/aws-get-session-token \"" >>~/.zshrc
-            show_msg "Activating aws-get-session-token..."
+            msg_ok "Activating aws-get-session-token"
 
             echo "alias aws-sso=\"${BASEDIR}/bin/aws-sso \"" >>~/.zshrc
-            show_msg "Activating aws-sso..."
+            msg_ok "Activating aws-sso"
 
             sudo ln -sf ${BASEDIR}/bin/aws-sso-cred /usr/local/bin/aws-sso-cred
-            show_msg "Activating aws-sso-cred..."
+            msg_ok "Activating aws-sso-cred"
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-aws' (side-by-side)..."
+            msg_warn "Installing as 'mec-aws' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/aws /usr/local/bin/mec-aws
             sudo ln -sf ${BASEDIR}/bin/aws-sso-cred /usr/local/bin/aws-sso-cred
             echo "> Run 'mec-aws' to use the Docker wrapper."
@@ -237,14 +237,14 @@ install_node() {
     detected=$(detect_existing_tool "node")
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
-        show_msg "Activating node (v22)..."
+        msg_ok "Activating node (v22)"
         sudo ln -sf ${BASEDIR}/bin/node /usr/local/bin/node
         sudo ln -sf ${BASEDIR}/bin/node /usr/local/bin/node24
 
-        show_msg "Activating node22..."
+        msg_ok "Activating node22"
         sudo ln -sf ${BASEDIR}/bin/node22 /usr/local/bin/node22
 
-        show_msg "Activating node20..."
+        msg_ok "Activating node20"
         sudo ln -sf ${BASEDIR}/bin/node20 /usr/local/bin/node20
     else
         local existing_path="${detected#external:}"
@@ -252,14 +252,14 @@ install_node() {
         local result=$?
         if [[ $result -eq 0 ]]; then
             # Replace
-            show_msg "Activating node..."
+            msg_ok "Activating node"
             sudo ln -sf ${BASEDIR}/bin/node /usr/local/bin/node
             sudo ln -sf ${BASEDIR}/bin/node /usr/local/bin/node24
             sudo ln -sf ${BASEDIR}/bin/node22 /usr/local/bin/node22
             sudo ln -sf ${BASEDIR}/bin/node20 /usr/local/bin/node20
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-node' (side-by-side)..."
+            msg_warn "Installing as 'mec-node' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/node /usr/local/bin/mec-node
             sudo ln -sf ${BASEDIR}/bin/node22 /usr/local/bin/node22
             sudo ln -sf ${BASEDIR}/bin/node20 /usr/local/bin/node20
@@ -279,14 +279,14 @@ install_npm() {
     detected=$(detect_existing_tool "npm")
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
-        show_msg "Activating npm (over NodeJS v22)..."
+        msg_ok "Activating npm (over NodeJS v22)"
         sudo ln -sf ${BASEDIR}/bin/npm /usr/local/bin/npm
         sudo ln -sf ${BASEDIR}/bin/npm /usr/local/bin/npm24
 
-        show_msg "Activating npm22 (over NodeJS v22)..."
+        msg_ok "Activating npm22 (over NodeJS v22)"
         sudo ln -sf ${BASEDIR}/bin/npm22 /usr/local/bin/npm22
 
-        show_msg "Activating npm20 (over NodeJS v20)..."
+        msg_ok "Activating npm20 (over NodeJS v20)"
         sudo ln -sf ${BASEDIR}/bin/npm20 /usr/local/bin/npm20
     else
         local existing_path="${detected#external:}"
@@ -294,14 +294,14 @@ install_npm() {
         local result=$?
         if [[ $result -eq 0 ]]; then
             # Replace
-            show_msg "Activating npm..."
+            msg_ok "Activating npm"
             sudo ln -sf ${BASEDIR}/bin/npm /usr/local/bin/npm
             sudo ln -sf ${BASEDIR}/bin/npm /usr/local/bin/npm24
             sudo ln -sf ${BASEDIR}/bin/npm22 /usr/local/bin/npm22
             sudo ln -sf ${BASEDIR}/bin/npm20 /usr/local/bin/npm20
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-npm' (side-by-side)..."
+            msg_warn "Installing as 'mec-npm' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/npm /usr/local/bin/mec-npm
             sudo ln -sf ${BASEDIR}/bin/npm22 /usr/local/bin/npm22
             sudo ln -sf ${BASEDIR}/bin/npm20 /usr/local/bin/npm20
@@ -328,7 +328,7 @@ install_npx() {
 
         if [[ "$npx_detected" == "none" || "$npx_detected" == "mec" ]]; then
             # npx not found or already mec — safe to install
-            show_msg "Activating npx (over NodeJS v22)..."
+            msg_ok "Activating npx (over NodeJS v22)"
             sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx
             sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx24
             sudo ln -sf ${BASEDIR}/bin/npx22 /usr/local/bin/npx22
@@ -342,13 +342,13 @@ install_npx() {
             handle_tool_conflict "npx" "$existing_path"
             local result=$?
             if [[ $result -eq 0 ]]; then
-                show_msg "Activating npx..."
+                msg_ok "Activating npx"
                 sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx
                 sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx24
                 sudo ln -sf ${BASEDIR}/bin/npx22 /usr/local/bin/npx22
                 sudo ln -sf ${BASEDIR}/bin/npx20 /usr/local/bin/npx20
             elif [[ $result -eq 1 ]]; then
-                show_msg "Installing as 'mec-npx' (side-by-side)..."
+                msg_warn "Installing as 'mec-npx' (side-by-side)"
                 sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/mec-npx
                 sudo ln -sf ${BASEDIR}/bin/npx22 /usr/local/bin/npx22
                 sudo ln -sf ${BASEDIR}/bin/npx20 /usr/local/bin/npx20
@@ -365,7 +365,7 @@ install_npx() {
         detected=$(detect_existing_tool "npx")
 
         if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
-            show_msg "Activating npx (over NodeJS v22)..."
+            msg_ok "Activating npx (over NodeJS v22)"
             sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx
             sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx24
             sudo ln -sf ${BASEDIR}/bin/npx22 /usr/local/bin/npx22
@@ -375,13 +375,13 @@ install_npx() {
             handle_tool_conflict "npx" "$existing_path"
             local result=$?
             if [[ $result -eq 0 ]]; then
-                show_msg "Activating npx..."
+                msg_ok "Activating npx"
                 sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx
                 sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/npx24
                 sudo ln -sf ${BASEDIR}/bin/npx22 /usr/local/bin/npx22
                 sudo ln -sf ${BASEDIR}/bin/npx20 /usr/local/bin/npx20
             elif [[ $result -eq 1 ]]; then
-                show_msg "Installing as 'mec-npx' (side-by-side)..."
+                msg_warn "Installing as 'mec-npx' (side-by-side)"
                 sudo ln -sf ${BASEDIR}/bin/npx /usr/local/bin/mec-npx
                 sudo ln -sf ${BASEDIR}/bin/npx22 /usr/local/bin/npx22
                 sudo ln -sf ${BASEDIR}/bin/npx20 /usr/local/bin/npx20
@@ -402,14 +402,14 @@ install_yarn() {
     detected=$(detect_existing_tool "yarn")
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
-        show_msg "Activating yarn (using NodeJS v22)..."
+        msg_ok "Activating yarn (using NodeJS v22)"
         sudo ln -sf ${BASEDIR}/bin/yarn /usr/local/bin/yarn
         sudo ln -sf ${BASEDIR}/bin/yarn /usr/local/bin/yarn24
 
-        show_msg "Activating yarn22..."
+        msg_ok "Activating yarn22"
         sudo ln -sf ${BASEDIR}/bin/yarn22 /usr/local/bin/yarn22
 
-        show_msg "Activating yarn20..."
+        msg_ok "Activating yarn20"
         sudo ln -sf ${BASEDIR}/bin/yarn20 /usr/local/bin/yarn20
     else
         local existing_path="${detected#external:}"
@@ -417,14 +417,14 @@ install_yarn() {
         local result=$?
         if [[ $result -eq 0 ]]; then
             # Replace
-            show_msg "Activating yarn..."
+            msg_ok "Activating yarn"
             sudo ln -sf ${BASEDIR}/bin/yarn /usr/local/bin/yarn
             sudo ln -sf ${BASEDIR}/bin/yarn /usr/local/bin/yarn24
             sudo ln -sf ${BASEDIR}/bin/yarn22 /usr/local/bin/yarn22
             sudo ln -sf ${BASEDIR}/bin/yarn20 /usr/local/bin/yarn20
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-yarn' (side-by-side)..."
+            msg_warn "Installing as 'mec-yarn' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/yarn /usr/local/bin/mec-yarn
             sudo ln -sf ${BASEDIR}/bin/yarn22 /usr/local/bin/yarn22
             sudo ln -sf ${BASEDIR}/bin/yarn20 /usr/local/bin/yarn20
@@ -444,22 +444,22 @@ install_serverless() {
     detected=$(detect_existing_tool "serverless")
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
-        show_msg "Activating serverless..."
+        msg_ok "Activating serverless"
         sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/serverless
         sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/sls
-        show_msg "> You can use 'serverless' or just 'sls' alias."
+        msg_info "You can use 'serverless' or just 'sls' alias."
     else
         local existing_path="${detected#external:}"
         handle_tool_conflict "serverless" "$existing_path"
         local result=$?
         if [[ $result -eq 0 ]]; then
             # Replace
-            show_msg "Activating serverless..."
+            msg_ok "Activating serverless"
             sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/serverless
             sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/sls
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-serverless' (side-by-side)..."
+            msg_warn "Installing as 'mec-serverless' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/serverless /usr/local/bin/mec-serverless
             echo "> Run 'mec-serverless' to use the Docker wrapper."
         else
@@ -478,7 +478,7 @@ install_terraform() {
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
         sudo ln -sf ${BASEDIR}/bin/terraform /usr/local/bin/terraform
-        show_msg "Activating terraform..."
+        msg_ok "Activating terraform"
     else
         local existing_path="${detected#external:}"
         handle_tool_conflict "terraform" "$existing_path"
@@ -486,10 +486,10 @@ install_terraform() {
         if [[ $result -eq 0 ]]; then
             # Replace
             sudo ln -sf ${BASEDIR}/bin/terraform /usr/local/bin/terraform
-            show_msg "Activating terraform..."
+            msg_ok "Activating terraform"
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-terraform' (side-by-side)..."
+            msg_warn "Installing as 'mec-terraform' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/terraform /usr/local/bin/mec-terraform
             echo "> Run 'mec-terraform' to use the Docker wrapper."
         else
@@ -508,7 +508,7 @@ install_speedtest() {
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
         sudo ln -sf ${BASEDIR}/bin/speedtest /usr/local/bin/speedtest
-        show_msg "Activating speedtest..."
+        msg_ok "Activating speedtest"
     else
         local existing_path="${detected#external:}"
         handle_tool_conflict "speedtest" "$existing_path"
@@ -516,10 +516,10 @@ install_speedtest() {
         if [[ $result -eq 0 ]]; then
             # Replace
             sudo ln -sf ${BASEDIR}/bin/speedtest /usr/local/bin/speedtest
-            show_msg "Activating speedtest..."
+            msg_ok "Activating speedtest"
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-speedtest' (side-by-side)..."
+            msg_warn "Installing as 'mec-speedtest' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/speedtest /usr/local/bin/mec-speedtest
             echo "> Run 'mec-speedtest' to use the Docker wrapper."
         else
@@ -538,11 +538,11 @@ install_gcloud() {
 
     # gcloud-login is mec-specific — always install it
     sudo ln -sf ${BASEDIR}/bin/gcloud-login /usr/local/bin/gcloud-login
-    show_msg "Activating gcloud-login..."
+    msg_ok "Activating gcloud-login"
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
         sudo ln -sf ${BASEDIR}/bin/gcloud /usr/local/bin/gcloud
-        show_msg "Activating gcloud..."
+        msg_ok "Activating gcloud"
     else
         local existing_path="${detected#external:}"
         handle_tool_conflict "gcloud" "$existing_path"
@@ -550,10 +550,10 @@ install_gcloud() {
         if [[ $result -eq 0 ]]; then
             # Replace
             sudo ln -sf ${BASEDIR}/bin/gcloud /usr/local/bin/gcloud
-            show_msg "Activating gcloud..."
+            msg_ok "Activating gcloud"
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-gcloud' (side-by-side)..."
+            msg_warn "Installing as 'mec-gcloud' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/gcloud /usr/local/bin/mec-gcloud
             echo "> Run 'mec-gcloud' to use the Docker wrapper."
         else
@@ -568,7 +568,7 @@ install_gcloud() {
 }
 
 install_yarn-plus() {
-    show_msg "Activating yarn-plus (Yarn with extra tools)..."
+    msg_ok "Activating yarn-plus (Yarn with extra tools)"
     sudo ln -sf ${BASEDIR}/bin/yarn-plus /usr/local/bin/yarn-plus
 
     track_install "yarn-plus"
@@ -582,12 +582,12 @@ install_yarn-berry() {
         if [[ $REPLACE_YARN == "Y" || $REPLACE_YARN == "y" ]]; then
             sudo ln -sf ${BASEDIR}/bin/yarn-berry $(which yarn)
             sudo ln -sf ${BASEDIR}/bin/yarn-berry /usr/local/bin/yarn
-            show_msg "Replacing yarn by yarn berry version..."
+            msg_ok "Replacing yarn by yarn berry version"
         fi
     fi
 
     sudo ln -sf ${BASEDIR}/bin/yarn-berry /usr/local/bin/yarn-berry
-    show_msg "Activating yarn-berry..."
+    msg_ok "Activating yarn-berry"
 
     track_install "yarn-berry"
 }
@@ -599,17 +599,17 @@ install_playwright() {
     # Build the self-sufficient Docker image with Chromium pre-installed
     local build_script="${BASEDIR}/docker/playwright/build"
     if [[ -f "$build_script" ]]; then
-        show_msg "Building davidcardoso/my-ez-cli:playwright-latest (this may take a moment)..."
+        msg_info "Building davidcardoso/my-ez-cli:playwright-latest (this may take a moment)..."
         if (cd "${BASEDIR}/docker/playwright" && bash build); then
-            echo "> Image davidcardoso/my-ez-cli:playwright-latest built successfully."
+            msg_ok "Image davidcardoso/my-ez-cli:playwright-latest built successfully."
         else
-            echo "WARNING: Docker image build failed. You can still run playwright using the upstream image." >&2
+            msg_err "Docker image build failed. You can still run playwright using the upstream image."
             echo "> To retry: cd ${BASEDIR}/docker/playwright && ./build" >&2
         fi
     fi
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
-        show_msg "Activating playwright..."
+        msg_ok "Activating playwright"
         sudo ln -sf ${BASEDIR}/bin/playwright /usr/local/bin/playwright
     else
         local existing_path="${detected#external:}"
@@ -617,11 +617,11 @@ install_playwright() {
         local result=$?
         if [[ $result -eq 0 ]]; then
             # Replace
-            show_msg "Activating playwright..."
+            msg_ok "Activating playwright"
             sudo ln -sf ${BASEDIR}/bin/playwright /usr/local/bin/playwright
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-playwright' (side-by-side)..."
+            msg_warn "Installing as 'mec-playwright' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/playwright /usr/local/bin/mec-playwright
             echo "> Run 'mec-playwright' to use the Docker wrapper."
         else
@@ -639,7 +639,7 @@ install_python() {
     detected=$(detect_existing_tool "python")
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
-        show_msg "Activating python..."
+        msg_ok "Activating python"
         sudo ln -sf ${BASEDIR}/bin/python /usr/local/bin/python
     else
         local existing_path="${detected#external:}"
@@ -647,11 +647,11 @@ install_python() {
         local result=$?
         if [[ $result -eq 0 ]]; then
             # Replace
-            show_msg "Activating python..."
+            msg_ok "Activating python"
             sudo ln -sf ${BASEDIR}/bin/python /usr/local/bin/python
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-python' (side-by-side)..."
+            msg_warn "Installing as 'mec-python' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/python /usr/local/bin/mec-python
             echo "> Run 'mec-python' to use the Docker wrapper."
         else
@@ -669,7 +669,7 @@ install_promptfoo() {
     detected=$(detect_existing_tool "promptfoo")
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
-        show_msg "Activating promptfoo..."
+        msg_ok "Activating promptfoo"
         sudo ln -sf ${BASEDIR}/bin/promptfoo /usr/local/bin/promptfoo
     else
         local existing_path="${detected#external:}"
@@ -677,11 +677,11 @@ install_promptfoo() {
         local result=$?
         if [[ $result -eq 0 ]]; then
             # Replace
-            show_msg "Activating promptfoo..."
+            msg_ok "Activating promptfoo"
             sudo ln -sf ${BASEDIR}/bin/promptfoo /usr/local/bin/promptfoo
         elif [[ $result -eq 1 ]]; then
             # Side-by-side
-            show_msg "Installing as 'mec-promptfoo' (side-by-side)..."
+            msg_warn "Installing as 'mec-promptfoo' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/promptfoo /usr/local/bin/mec-promptfoo
             echo "> Run 'mec-promptfoo' to use the Docker wrapper."
         else
@@ -695,7 +695,7 @@ install_promptfoo() {
 }
 
 install_promptfoo-server() {
-    show_msg "Activating promptfoo-server..."
+    msg_ok "Activating promptfoo-server"
     sudo ln -sf ${BASEDIR}/bin/promptfoo-server /usr/local/bin/promptfoo-server
 
     track_install "promptfoo-server"
@@ -740,7 +740,7 @@ handle_tool_conflict() {
         1) return 1 ;;
         2)
             echo ""
-            echo "Warning: This will overwrite your existing '$tool'."
+            msg_warn "This will overwrite your existing '$tool'."
             read -p "Are you sure? [y/N]: " confirm
             if [[ "$confirm" == "y" || "$confirm" == "Y" ]]; then
                 return 0
@@ -809,7 +809,7 @@ uninstall_native_claude() {
             if brew uninstall claude 2>/dev/null; then
                 return 0
             else
-                echo "Warning: brew uninstall failed."
+                msg_warn "brew uninstall failed."
                 return 1
             fi
             ;;
@@ -818,7 +818,7 @@ uninstall_native_claude() {
             if rm -f "$claude_path" 2>/dev/null; then
                 return 0
             else
-                echo "Warning: Could not remove $claude_path"
+                msg_warn "Could not remove $claude_path"
                 return 1
             fi
             ;;
@@ -827,7 +827,7 @@ uninstall_native_claude() {
             if npm uninstall -g @anthropic-ai/claude-code 2>/dev/null; then
                 return 0
             else
-                echo "Warning: npm uninstall failed."
+                msg_warn "npm uninstall failed."
                 return 1
             fi
             ;;
@@ -845,7 +845,7 @@ install_claude() {
 
     if [[ "$detected" == "none" || "$detected" == "mec" ]]; then
         # Fresh install or already mec-managed — install both symlinks
-        show_msg "Activating claude (Claude Code CLI)..."
+        msg_ok "Activating claude (Claude Code CLI)"
         sudo ln -sf ${BASEDIR}/bin/claude /usr/local/bin/claude
         sudo ln -sf ${BASEDIR}/bin/claude /usr/local/bin/mec-claude
         track_install "claude"
@@ -878,14 +878,14 @@ install_claude() {
 
     case "$choice" in
         1)
-            show_msg "Installing as 'mec-claude' (side-by-side)..."
+            msg_warn "Installing as 'mec-claude' (side-by-side)"
             sudo ln -sf ${BASEDIR}/bin/claude /usr/local/bin/mec-claude
             track_install "claude"
             echo "> Run 'mec-claude' to use the Docker wrapper."
             ;;
         2)
             echo ""
-            echo "Warning: This will remove your existing 'claude' installation."
+            msg_warn "This will remove your existing 'claude' installation."
             read -p "Are you sure? [y/N]: " confirm
             if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
                 echo "Cancelled. Falling back to side-by-side install..."
@@ -895,7 +895,7 @@ install_claude() {
                 return
             fi
             if uninstall_native_claude "$existing_path"; then
-                show_msg "Installing claude (Claude Code CLI)..."
+                msg_ok "Installing claude (Claude Code CLI)"
                 sudo ln -sf ${BASEDIR}/bin/claude /usr/local/bin/claude
                 sudo ln -sf ${BASEDIR}/bin/claude /usr/local/bin/mec-claude
                 track_install "claude"
@@ -914,7 +914,7 @@ install_claude() {
 }
 
 install_mec() {
-    show_msg "Activating mec (my-ez-cli command)..."
+    msg_ok "Activating mec (my-ez-cli command)"
     sudo ln -sf ${BASEDIR}/bin/mec /usr/local/bin/mec
 
     # Export MEC_HOME to the user's shell profile so it is available in
@@ -923,7 +923,7 @@ install_mec() {
         echo '' >> ~/.zshrc
         echo '# my-ez-cli' >> ~/.zshrc
         echo 'export MEC_HOME="${MEC_HOME:-${HOME}/.my-ez-cli}"' >> ~/.zshrc
-        show_msg "Added MEC_HOME to ~/.zshrc — run 'source ~/.zshrc' to apply in your current session."
+        msg_info "Added MEC_HOME to ~/.zshrc — run 'source ~/.zshrc' to apply in your current session."
     fi
 
     track_install "mec"
@@ -964,7 +964,7 @@ uninstall_aws() {
     fi
 
     track_uninstall "aws"
-    show_msg "Uninstalled aws..."
+    msg_ok "Uninstalled aws"
 }
 
 uninstall_node() {
@@ -975,7 +975,7 @@ uninstall_node() {
     sudo rm -f /usr/local/bin/node24
 
     track_uninstall "node"
-    show_msg "Uninstalled node..."
+    msg_ok "Uninstalled node"
 }
 
 uninstall_npm() {
@@ -986,7 +986,7 @@ uninstall_npm() {
     sudo rm -f /usr/local/bin/npm24
 
     track_uninstall "npm"
-    show_msg "Uninstalled npm..."
+    msg_ok "Uninstalled npm"
 }
 
 uninstall_npx() {
@@ -997,7 +997,7 @@ uninstall_npx() {
     sudo rm -f /usr/local/bin/npx24
 
     track_uninstall "npx"
-    show_msg "Uninstalled npx..."
+    msg_ok "Uninstalled npx"
 }
 
 uninstall_yarn() {
@@ -1008,21 +1008,21 @@ uninstall_yarn() {
     sudo rm -f /usr/local/bin/yarn24
 
     track_uninstall "yarn"
-    show_msg "Uninstalled yarn..."
+    msg_ok "Uninstalled yarn"
 }
 
 uninstall_yarn-plus() {
     sudo rm -f /usr/local/bin/yarn-plus
 
     track_uninstall "yarn-plus"
-    show_msg "Uninstalled yarn-plus..."
+    msg_ok "Uninstalled yarn-plus"
 }
 
 uninstall_yarn-berry() {
     sudo rm -f /usr/local/bin/yarn-berry
 
     track_uninstall "yarn-berry"
-    show_msg "Uninstalled yarn-berry..."
+    msg_ok "Uninstalled yarn-berry"
 }
 
 uninstall_serverless() {
@@ -1031,7 +1031,7 @@ uninstall_serverless() {
     sudo rm -f /usr/local/bin/sls
 
     track_uninstall "serverless"
-    show_msg "Uninstalled serverless..."
+    msg_ok "Uninstalled serverless"
 }
 
 uninstall_terraform() {
@@ -1039,7 +1039,7 @@ uninstall_terraform() {
     sudo rm -f /usr/local/bin/mec-terraform
 
     track_uninstall "terraform"
-    show_msg "Uninstalled terraform..."
+    msg_ok "Uninstalled terraform"
 }
 
 uninstall_speedtest() {
@@ -1047,7 +1047,7 @@ uninstall_speedtest() {
     sudo rm -f /usr/local/bin/mec-speedtest
 
     track_uninstall "speedtest"
-    show_msg "Uninstalled speedtest..."
+    msg_ok "Uninstalled speedtest"
 }
 
 uninstall_gcloud() {
@@ -1056,7 +1056,7 @@ uninstall_gcloud() {
     sudo rm -f /usr/local/bin/gcloud-login
 
     track_uninstall "gcloud"
-    show_msg "Uninstalled gcloud..."
+    msg_ok "Uninstalled gcloud"
 }
 
 uninstall_playwright() {
@@ -1064,7 +1064,7 @@ uninstall_playwright() {
     sudo rm -f /usr/local/bin/mec-playwright
 
     track_uninstall "playwright"
-    show_msg "Uninstalled playwright..."
+    msg_ok "Uninstalled playwright"
 }
 
 uninstall_python() {
@@ -1072,7 +1072,7 @@ uninstall_python() {
     sudo rm -f /usr/local/bin/mec-python
 
     track_uninstall "python"
-    show_msg "Uninstalled python..."
+    msg_ok "Uninstalled python"
 }
 
 uninstall_promptfoo() {
@@ -1080,14 +1080,14 @@ uninstall_promptfoo() {
     sudo rm -f /usr/local/bin/mec-promptfoo
 
     track_uninstall "promptfoo"
-    show_msg "Uninstalled promptfoo..."
+    msg_ok "Uninstalled promptfoo"
 }
 
 uninstall_promptfoo-server() {
     sudo rm -f /usr/local/bin/promptfoo-server
 
     track_uninstall "promptfoo-server"
-    show_msg "Uninstalled promptfoo-server..."
+    msg_ok "Uninstalled promptfoo-server"
 }
 
 uninstall_claude() {
@@ -1095,7 +1095,7 @@ uninstall_claude() {
     sudo rm -f /usr/local/bin/mec-claude
 
     track_uninstall "claude"
-    show_msg "Uninstalled claude..."
+    msg_ok "Uninstalled claude"
 }
 
 uninstall_mec() {
@@ -1109,7 +1109,7 @@ uninstall_mec() {
     fi
 
     track_uninstall "mec"
-    show_msg "Uninstalled mec..."
+    msg_ok "Uninstalled mec"
 }
 
 # Status functions
@@ -1193,7 +1193,7 @@ Available tools:"
         if [ "$selection" = "all" ]; then
             echo "Installing all tools..."
             install_all
-            show_msg "> All tools installed successfully!"
+            msg_ok "All tools installed successfully!"
             break
         fi
 
@@ -1211,7 +1211,7 @@ Available tools:"
                                 "uninstall_${tool}"
                                 ;;
                             *)
-                                echo "Error: Invalid tool name: $tool"
+                                msg_err "Invalid tool name: $tool"
                                 ;;
                         esac
                     else
@@ -1238,7 +1238,7 @@ Available tools:"
                             "install_${tool}"
                             ;;
                         *)
-                            echo "Error: Invalid tool name: $tool"
+                            msg_err "Invalid tool name: $tool"
                             ;;
                     esac
                 fi
@@ -1256,8 +1256,7 @@ Available tools:"
 
 handle_install() {
     if [ $# -eq 0 ]; then
-        echo "Error: No tools specified."
-        echo "Usage: ${0} install <tool1> <tool2> ... | all"
+        msg_err "No tools specified. Usage: ${0} install <tool1> <tool2> ... | all"
         exit 1
     fi
 
@@ -1269,7 +1268,7 @@ handle_install() {
 
     if [ "$1" = "all" ]; then
         install_all
-        show_msg "> All tools installed successfully!"
+        msg_ok "All tools installed successfully!"
         return
     fi
 
@@ -1283,7 +1282,7 @@ handle_install() {
                 fi
                 ;;
             *)
-                echo "Error: Unknown tool '$tool'"
+                msg_err "Unknown tool '$tool'"
                 echo "Run '${0} help' for usage information"
                 exit 1
                 ;;
@@ -1293,8 +1292,7 @@ handle_install() {
 
 handle_uninstall() {
     if [ $# -eq 0 ]; then
-        echo "Error: No tools specified."
-        echo "Usage: ${0} uninstall <tool1> <tool2> ..."
+        msg_err "No tools specified. Usage: ${0} uninstall <tool1> <tool2> ..."
         exit 1
     fi
 
@@ -1314,7 +1312,7 @@ handle_uninstall() {
                 fi
                 ;;
             *)
-                echo "Error: Unknown tool '$tool'"
+                msg_err "Unknown tool '$tool'"
                 echo "Run '${0} help' for usage information"
                 exit 1
                 ;;
@@ -1369,7 +1367,7 @@ else
             exit 0
             ;;
         *)
-            echo "Error: Unknown command '$command'"
+            msg_err "Unknown command '$command'"
             echo ""
             show_help
             exit 1
@@ -1378,6 +1376,6 @@ else
 fi
 
 # End message
-show_msg "> Check the scripts in '${BASEDIR}/bin/' folder."
-show_msg "> Check the '${BASEDIR}/README.md' file."
-show_msg "Thanks for using My Ez CLI ;)"
+msg_info "Check the scripts in '${BASEDIR}/bin/' folder."
+msg_info "Check the '${BASEDIR}/README.md' file."
+msg_ok "Thanks for using My Ez CLI ;)"

--- a/setup.sh
+++ b/setup.sh
@@ -2,47 +2,17 @@
 set -e
 
 BASEDIR=$(cd $(dirname "${0}") && pwd)
-TRACKING_FILE="$HOME/.my-ez-cli/installed"
 
-# Create .my-ez-cli directory if it doesn't exist
-mkdir -p "$HOME/.my-ez-cli"
+# Load shared utilities (color helpers, MEC_HOME, etc.)
+# shellcheck source=bin/utils/common.sh
+source "${BASEDIR}/bin/utils/common.sh"
 
-# Helpers
+TRACKING_FILE="${MEC_HOME}/installed"
 
-# ---------------------------------------------------------------------------
-# Output helpers — TTY-safe color/icon output
-# ---------------------------------------------------------------------------
-# Set ANSI codes only when stdout is a terminal
-_G="" _Y="" _R="" _B="" _RST=""
-if [ -t 1 ]; then
-    _G=$(printf '\033[0;32m')   # green
-    _Y=$(printf '\033[0;33m')   # yellow
-    _R=$(printf '\033[0;31m')   # red
-    _B=$(printf '\033[1m')      # bold
-    _RST=$(printf '\033[0m')    # reset
-fi
+# Create MEC_HOME directory if it doesn't exist
+mkdir -p "${MEC_HOME}"
 
-# msg_ok "message"   — green ✓  (success)
-msg_ok() {
-    printf '%s\n' "${_G}✓${_RST} ${1}"
-}
-
-# msg_warn "message" — yellow ⚠  (non-fatal warning or side-by-side notice)
-msg_warn() {
-    printf '%s\n' "${_Y}⚠${_RST} ${1}" >&2
-}
-
-# msg_err "message"  — red ✗  (fatal error, writes to stderr)
-msg_err() {
-    printf '%s\n' "${_R}✗${_RST} ${1}" >&2
-}
-
-# msg_info "message" — bold →  (informational note)
-msg_info() {
-    printf '%s\n' "${_B}→${_RST} ${1}"
-}
-
-# show_msg kept as alias to msg_ok for backward compatibility during migration
+# show_msg kept as alias to msg_ok for backward compatibility
 show_msg() {
     msg_ok "${1}"
 }

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -71,7 +71,7 @@ setup() {
 }
 
 @test "setup.sh creates tracking directory" {
-    grep -q "mkdir -p.*/.my-ez-cli" "$SETUP_SCRIPT"
+    grep -q 'mkdir -p.*MEC_HOME' "$SETUP_SCRIPT"
 }
 
 @test "setup.sh has install functions for all tools" {

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -200,3 +200,30 @@ _sys_path="/usr/bin:/bin"
     [ "$status" -eq 0 ]
     [[ "$output" == "unknown:"* ]]
 }
+
+@test "setup.sh msg_ok outputs check icon and message" {
+    run bash -c "source ${MEC_PROJECT_DIR}/setup.sh 2>/dev/null; msg_ok 'tool installed'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "tool installed" ]]
+    [[ "$output" =~ "✓" ]]
+}
+
+@test "setup.sh msg_warn outputs warning icon and message" {
+    run bash -c "source ${MEC_PROJECT_DIR}/setup.sh 2>/dev/null; msg_warn 'side-by-side' 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "side-by-side" ]]
+    [[ "$output" =~ "⚠" ]]
+}
+
+@test "setup.sh msg_err outputs error icon and message" {
+    run bash -c "source ${MEC_PROJECT_DIR}/setup.sh 2>/dev/null; msg_err 'failed' 2>&1"
+    [[ "$output" =~ "failed" ]]
+    [[ "$output" =~ "✗" ]]
+}
+
+@test "setup.sh msg_info outputs info icon and message" {
+    run bash -c "source ${MEC_PROJECT_DIR}/setup.sh 2>/dev/null; msg_info 'note about something'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "note about something" ]]
+    [[ "$output" =~ "→" ]]
+}

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -41,7 +41,7 @@ setup() {
 @test "setup.sh rejects unknown command" {
     run "$SETUP_SCRIPT" unknown-command
     [ "$status" -ne 0 ]
-    [[ "$output" =~ "Error: Unknown command" ]]
+    [[ "$output" =~ "Unknown command" ]]
 }
 
 @test "setup.sh install requires tool name" {


### PR DESCRIPTION
## Summary

- Add TTY-safe color/icon output helpers to `setup.sh`: `msg_ok` (green ✓), `msg_warn` (yellow ⚠), `msg_err` (red ✗), `msg_info` (bold →)
- Replace all ~60 `show_msg` banner calls and bare `echo "Warning:"`/`echo "Error:"` calls with semantic helpers
- Style `show_begin`, `show_status` (colored ✓/✗ per tool), and `interactive_menu` headers with bold/colors
- Add `_mec_err` helper to `bin/mec`; use in `mec_install`/`mec_uninstall` error paths
- ANSI codes emitted only when stdout/stderr is a TTY — safe in CI and piped output

## Test plan

- [x] 4 new bats tests for `msg_ok`/`msg_warn`/`msg_err`/`msg_info` (all 30 tests pass)
- [x] 2 new CI smoke steps in `smoke-tests` job
- [x] `bash -n setup.sh bin/mec` — both syntax-clean
- [x] Smoke test: `mec install` / `mec uninstall` (no args) shows `✗` usage error
- [x] Smoke test: `mec setup status` shows bold header + colored ✓/✗ per tool

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)