### PR TITLE
feat(ai): accept session ID in mec ai analyze (#105)

### DIFF
--- a/bin/mec
+++ b/bin/mec
@@ -243,14 +243,21 @@ mec_ai() {
             _mec_ai_logs "$@"
             ;;
         analyze)
-            local log_file="$1"
-            if [ -z "$log_file" ]; then
-                echo "Usage: mec ai analyze <log-file>" >&2
+            local _input="$1"
+            if [ -z "$_input" ]; then
+                echo "Usage: mec ai analyze <log-file|session-id>" >&2
                 return 1
             fi
-            if [ ! -f "$log_file" ]; then
-                echo "Error: File not found: $log_file" >&2
-                return 1
+
+            local log_file
+            if [ -f "$_input" ]; then
+                log_file="$_input"
+            else
+                log_file=$(log_find_by_session_id "$_input")
+                if [ -z "$log_file" ]; then
+                    echo "Error: Not a file and no session found for: $_input" >&2
+                    return 1
+                fi
             fi
 
             # Check Claude Code availability
@@ -297,7 +304,7 @@ mec_ai() {
             printf '%s\n' "  last                Show the most recent AI analysis"
             printf '%s\n' "  show <session_id>   Show a specific session by ID"
             printf '%s\n' "  logs [--last N]     List recent sessions with AI status (default: last 20)"
-            printf '%s\n' "  analyze <log-file>  Analyze a log file with Claude Code"
+            printf '%s\n' "  analyze <log-file|session-id>  Analyze a log file with Claude Code"
             printf '%s\n' "  help                Show this help"
             printf '%s\n' ""
             printf '%s\n' "${_b}REQUIREMENTS${_r} (one of)"
@@ -320,6 +327,7 @@ mec_ai() {
             printf '%s\n' "  mec ai last"
             printf '%s\n' "  mec ai logs --last 5"
             printf '%s\n' "  mec ai analyze \$MEC_HOME/logs/node/2026-01-01_12-00-00.json"
+            printf '%s\n' "  mec ai analyze mec-node-1774880478"
             printf '%s\n' "  mec config set ai.claude.model haiku"
             ;;
         *)
@@ -433,9 +441,8 @@ _mec_ai_show() {
         return 1
     fi
 
-    local log_dir="${MEC_LOG_DIR:-${MEC_HOME}/logs}"
     local log_file
-    log_file=$(grep -rl "\"session_id\".*\"${session_id}\"" "$log_dir" 2>/dev/null | grep -v "\.bak$" | grep "\.json$" | head -1)
+    log_file=$(log_find_by_session_id "$session_id")
 
     if [ -z "$log_file" ]; then
         echo "Session not found: $session_id" >&2

--- a/bin/utils/log-manager.sh
+++ b/bin/utils/log-manager.sh
@@ -291,6 +291,22 @@ log_latest() {
     log_list "$TOOL_NAME" 1
 }
 
+# Find a log file by session ID
+# Usage: log_find_by_session_id "mec-node-1774880478"
+# Returns: absolute path to .json log file, or empty string if not found
+log_find_by_session_id() {
+    local session_id="$1"
+    local log_dir="${LOG_DIR:-$DEFAULT_LOG_DIR}"
+
+    [ -z "$session_id" ] && return 0
+    [ ! -d "$log_dir" ] && return 0
+
+    grep -rl "\"session_id\"[[:space:]]*:[[:space:]]*\"${session_id}\"" "$log_dir" 2>/dev/null \
+        | grep -v "\.bak$" \
+        | grep "\.json$" \
+        | head -1
+}
+
 # ----------------------------------------------------------------------------
 # Initialization
 # ----------------------------------------------------------------------------

--- a/services/dashboard/frontend/src/pages/SessionDetailPage.vue
+++ b/services/dashboard/frontend/src/pages/SessionDetailPage.vue
@@ -40,10 +40,10 @@
           <span class="meta-label">AI Status</span>
           <Tag :value="session.ai_status" :severity="aiSeverity(session.ai_status)" />
         </div>
-        <div v-if="session.ai_status === 'none' && session.log_file" class="meta-item meta-item--wide">
+        <div v-if="session.ai_status === 'none'" class="meta-item meta-item--wide">
           <span class="meta-label">Run AI Analysis</span>
           <div class="session-id-row">
-            <span class="meta-value mono" style="font-size: 11px;">mec ai analyze {{ session.log_file }}</span>
+            <span class="meta-value mono" style="font-size: 11px;">mec ai analyze {{ session.session_id }}</span>
             <Button
               icon="pi pi-copy"
               text
@@ -185,7 +185,7 @@ async function copyResume() {
 
 async function copyAnalyze() {
   try {
-    await navigator.clipboard.writeText(`mec ai analyze ${session.value?.log_file}`)
+    await navigator.clipboard.writeText(`mec ai analyze ${session.value?.session_id}`)
     copiedAnalyze.value = true
     setTimeout(() => { copiedAnalyze.value = false }, 2000)
   } catch { /* noop */ }

--- a/tests/unit/test-log-manager.bats
+++ b/tests/unit/test-log-manager.bats
@@ -323,3 +323,42 @@ EOF
     [ "$tool" = "yarn" ]
     [ "$exit_code" = "0" ]
 }
+
+# ----------------------------------------------------------------------------
+# log_find_by_session_id
+# ----------------------------------------------------------------------------
+
+@test "log_find_by_session_id returns log file path for known session" {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local log_file="$tmpdir/node/2026-01-01_10-00-00.json"
+    mkdir -p "$tmpdir/node"
+    echo '{"session_id": "mec-node-9999999999", "tool": "node"}' > "$log_file"
+    LOG_DIR="$tmpdir"
+
+    run log_find_by_session_id "mec-node-9999999999"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$log_file" ]
+    rm -rf "$tmpdir"
+}
+
+@test "log_find_by_session_id returns empty for unknown session" {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/node"
+    LOG_DIR="$tmpdir"
+
+    run log_find_by_session_id "mec-node-0000000000"
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    rm -rf "$tmpdir"
+}
+
+@test "log_find_by_session_id returns empty for empty input" {
+    run log_find_by_session_id ""
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

- `mec ai analyze` now accepts either a log file path or a session ID (e.g. `mec-node-1774880478`)
- Added `log_find_by_session_id()` to `log-manager.sh` — grep-based lookup, shell-only, consistent with existing patterns
- Refactored `_mec_ai_show()` to use the new function, removing inline grep duplication
- Updated help text and examples

## Test plan

- [x] 26/26 unit tests passing (`bats tests/unit/test-log-manager.bats`)
- [x] `mec ai analyze mec-node-<id>` resolves to correct log file and runs analysis
- [x] `mec ai analyze /path/to/log.json` still works identically (backward compatible)
- [x] `mec ai analyze mec-node-0000000000` prints clear error and exits 1
- [x] `mec ai help` shows `<log-file|session-id>` and new session ID example

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)