### PR TITLE
fix(gcloud): handle missing gcloud-config container gracefully (#111)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,7 @@ jobs:
           - common-utils
           - dashboard
           - doctor
+          - gcloud
           - node
           - npm
           - purge

--- a/bin/gcloud
+++ b/bin/gcloud
@@ -9,6 +9,12 @@ MEC_BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Check Docker availability
 check_docker
 
+# Guard: gcloud-config container must exist (created by mec gcloud-login)
+if ! docker inspect gcloud-config >/dev/null 2>&1; then
+    echo "Error: GCP credentials container not found. Run 'mec gcloud-login' first." >&2
+    exit 1
+fi
+
 IMAGE=eu.gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
 WORKDIR=/app
 

--- a/tests/unit/test-gcloud.bats
+++ b/tests/unit/test-gcloud.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+# Test gcloud wrapper script
+
+setup() {
+    BASEDIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+}
+
+@test "gcloud script exists and is executable" {
+    [ -x "$BASEDIR/bin/gcloud" ]
+}
+
+@test "gcloud script has valid syntax" {
+    run bash -n "$BASEDIR/bin/gcloud"
+    [ "$status" -eq 0 ]
+}
+
+@test "gcloud exits with error when gcloud-config container is missing" {
+    # Stub docker to simulate missing gcloud-config container
+    docker() {
+        if [ "$1" = "inspect" ] && [ "$2" = "gcloud-config" ]; then
+            return 1
+        fi
+        command docker "$@"
+    }
+    export -f docker
+
+    run bash -c "
+        docker() {
+            if [ \"\$1\" = 'inspect' ] && [ \"\$2\" = 'gcloud-config' ]; then
+                return 1
+            fi
+            command docker \"\$@\"
+        }
+        export -f docker
+        source '$BASEDIR/bin/utils/common.sh' 2>/dev/null || true
+        SKIP_DEPENDENCY_CHECK=1 bash '$BASEDIR/bin/gcloud' version 2>&1
+    "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"gcloud-config"* ]] || [[ "$output" == *"gcloud-login"* ]]
+}
+
+@test "gcloud error message mentions mec gcloud-login" {
+    run bash -c "
+        docker() {
+            if [ \"\$1\" = 'inspect' ] && [ \"\$2\" = 'gcloud-config' ]; then
+                return 1
+            fi
+            command docker \"\$@\"
+        }
+        export -f docker
+        SKIP_DEPENDENCY_CHECK=1 bash '$BASEDIR/bin/gcloud' 2>&1
+    "
+    [[ "$output" == *"mec gcloud-login"* ]]
+}


### PR DESCRIPTION
## Summary

- Adds a pre-flight `docker inspect gcloud-config` check in `bin/gcloud` before attempting to run
- Exits with a clear message directing the user to run `mec gcloud-login` when the credentials container is missing, instead of surfacing a cryptic Docker daemon error (`No such container: gcloud-config`)
- Adds `tests/unit/test-gcloud.bats` with 4 unit tests covering the guard behavior
- Wires `gcloud` into the `unit-tests` CI matrix in `.github/workflows/test.yml`

## Test plan

- [x] `bats tests/unit/test-gcloud.bats` — all 4 tests pass
- [x] `bash -n bin/gcloud` — syntax check passes
- [x] Manual: run `bin/gcloud version` without a `gcloud-config` container → should print `Error: GCP credentials container not found. Run 'mec gcloud-login' first.` and exit 1

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)