### PR TITLE
feat(ai): display AI execution time and token usage in TUI and dashboard (#94)

### DIFF
--- a/bin/mec
+++ b/bin/mec
@@ -276,19 +276,22 @@ mec_ai() {
 
             echo "Analyzing: $log_file"
             echo ""
+            _mec_ai_notify "$log_file"
 
-            run_claude_analysis "$log_file"
+            # Snapshot env vars before backgrounding (same pattern as trigger_ai_analysis)
+            local _api_key="${ANTHROPIC_API_KEY:-}"
+            local _oauth_token="${CLAUDE_CODE_OAUTH_TOKEN:-}"
+            local _ai_enabled="${MEC_AI_ENABLED:-}"
+            local _home="${HOME}"
+            local _pwd="${PWD}"
 
-            local _session_id
-            _session_id=$(grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$log_file" \
-                | sed 's/.*"session_id"[^"]*"\([^"]*\)".*/\1/')
-            _session_id="${_session_id:-$(basename "$log_file" .json)}"
-            local _dashboard_port
-            _dashboard_port=$(config_get_default "ai.dashboard.port" "4242" 2>/dev/null || echo "4242")
-            echo ""
-            echo "Session:  $_session_id"
-            echo "Results:  http://localhost:${_dashboard_port}/sessions/${_session_id}"
-            echo "          (or: mec ai last)"
+            ( ANTHROPIC_API_KEY="$_api_key" \
+              CLAUDE_CODE_OAUTH_TOKEN="$_oauth_token" \
+              MEC_AI_ENABLED="$_ai_enabled" \
+              HOME="$_home" \
+              PWD="$_pwd" \
+              run_claude_analysis "$log_file" ) &
+            disown
             ;;
         help|--help|-h)
             local _b="" _r=""
@@ -352,7 +355,7 @@ _mec_ai_print_session() {
     local ai_file ai_status result
     ai_file=$(echo "$log_file" | sed 's|/logs/|/ai-analyses/|')
 
-    local claude_session_id=""
+    local claude_session_id="" exec_time_ms="" tokens_in="" tokens_out=""
     if [ -f "$ai_file" ]; then
         if command -v python3 >/dev/null 2>&1; then
             result=$(python3 -c "
@@ -372,6 +375,16 @@ print(items[-1][0] if items else '', end='')
         else
             result=$(grep '"result"' "$ai_file" 2>/dev/null | sed 's/.*"result"[[:space:]]*:[[:space:]]*"\(.*\)"/\1/' | head -1 | sed 's/\\n/\n/g; s/\\t/\t/g')
         fi
+        # Extract AI metrics from sidecar (pretty-printed JSON — one field per line)
+        exec_time_ms=$(grep '"execution_time_ms"' "$ai_file" 2>/dev/null \
+            | sed 's/.*"execution_time_ms"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/' \
+            | tail -1)
+        tokens_in=$(grep '"input"' "$ai_file" 2>/dev/null \
+            | sed 's/.*"input"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/' \
+            | tail -1)
+        tokens_out=$(grep '"output"' "$ai_file" 2>/dev/null \
+            | sed 's/.*"output"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/' \
+            | tail -1)
         if [ -n "$result" ]; then
             ai_status="done"
         else
@@ -381,15 +394,23 @@ print(items[-1][0] if items else '', end='')
         ai_status="none"
     fi
 
-    local dashboard_port
-    dashboard_port=$(config_get_default "ai.dashboard.port" "4242" 2>/dev/null || echo "4242")
+    local dashboard_url
+    dashboard_url=$(_mec_dashboard_url)
 
     echo "Session:   ${session_id:-unknown}"
     echo "Tool:      ${tool:-unknown}"
     echo "Timestamp: ${start_time:-unknown}"
     echo "Exit code: ${exit_code:-unknown}"
     echo "AI status: $ai_status"
-    echo "Dashboard: http://localhost:${dashboard_port}/sessions/${session_id}"
+    if [ -n "$exec_time_ms" ]; then
+        local exec_time_s
+        exec_time_s=$(echo "$exec_time_ms" | awk '{printf "%.1fs", $1/1000}')
+        echo "AI time:   ${exec_time_s}"
+    fi
+    if [ -n "$tokens_in" ] || [ -n "$tokens_out" ]; then
+        echo "Tokens:    in=${tokens_in:-—} • out=${tokens_out:-—}"
+    fi
+    echo "Dashboard: ${dashboard_url}/sessions/${session_id}"
     if [ -n "$claude_session_id" ]; then
         echo "Resume:    claude --resume ${claude_session_id}"
     fi
@@ -486,8 +507,8 @@ _mec_ai_logs() {
         return 0
     fi
 
-    printf "%-21s %-12s %-6s %-10s %s\n" "TIMESTAMP" "TOOL" "EXIT" "AI" "SESSION ID"
-    printf "%-21s %-12s %-6s %-10s %s\n" "---------------------" "------------" "------" "----------" "----------"
+    printf "%-21s %-12s %-6s %-10s %-8s %s\n" "TIMESTAMP" "TOOL" "EXIT" "AI" "AI TIME" "SESSION ID"
+    printf "%-21s %-12s %-6s %-10s %-8s %s\n" "---------------------" "------------" "------" "----------" "--------" "----------"
 
     echo "$log_files" | while IFS= read -r log_file; do
         [ -f "$log_file" ] || continue
@@ -517,7 +538,18 @@ _mec_ai_logs() {
             ai_status="none"
         fi
 
-        printf "%-21s %-12s %-6s %-10s %s\n" "$ts_display" "${tool:-?}" "${exit_code:-?}" "$ai_status" "${session_id:-?}"
+        local ai_time="--"
+        if [ "$ai_status" = "done" ] && [ -f "$ai_file" ]; then
+            local _exec_ms
+            _exec_ms=$(grep '"execution_time_ms"' "$ai_file" 2>/dev/null \
+                | sed 's/.*"execution_time_ms"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/' \
+                | tail -1)
+            if [ -n "$_exec_ms" ]; then
+                ai_time=$(echo "$_exec_ms" | awk '{printf "%.1fs", $1/1000}')
+            fi
+        fi
+
+        printf "%-21s %-12s %-6s %-10s %-8s %s\n" "$ts_display" "${tool:-?}" "${exit_code:-?}" "$ai_status" "$ai_time" "${session_id:-?}"
     done
 }
 
@@ -1131,6 +1163,8 @@ mec_dashboard() {
     local subcmd="${1:-help}"
     shift 2>/dev/null || true
 
+    local dashboard_url
+    dashboard_url=$(_mec_dashboard_url)
     local dashboard_port
     dashboard_port=$(config_get_default "ai.dashboard.port" "4242" 2>/dev/null || echo "4242")
 
@@ -1140,7 +1174,7 @@ mec_dashboard() {
                 local state
                 state=$(docker inspect --format '{{.State.Status}}' "$MEC_DASHBOARD_CONTAINER" 2>/dev/null)
                 if [ "$state" = "running" ]; then
-                    echo "Dashboard is already running at http://localhost:${dashboard_port}"
+                    echo "Dashboard is already running at ${dashboard_url}"
                     return 0
                 fi
                 # Container exists but stopped — remove it first
@@ -1161,8 +1195,8 @@ mec_dashboard() {
                 "$MEC_IMAGE_DASHBOARD" >/dev/null
 
             echo "Dashboard started"
-            echo "  UI  →  http://localhost:${dashboard_port}"
-            echo "  API →  http://localhost:${dashboard_port}/api"
+            echo "  UI  →  ${dashboard_url}"
+            echo "  API →  ${dashboard_url}/api"
             ;;
         stop)
             if ! docker inspect "$MEC_DASHBOARD_CONTAINER" >/dev/null 2>&1; then
@@ -1182,17 +1216,17 @@ mec_dashboard() {
             state=$(docker inspect --format '{{.State.Status}}' "$MEC_DASHBOARD_CONTAINER" 2>/dev/null)
             echo "Dashboard: $state"
             if [ "$state" = "running" ]; then
-                echo "  UI  →  http://localhost:${dashboard_port}"
-                echo "  API →  http://localhost:${dashboard_port}/api"
+                echo "  UI  →  ${dashboard_url}"
+                echo "  API →  ${dashboard_url}/api"
             fi
             ;;
         open)
             if command -v open >/dev/null 2>&1; then
-                open "http://localhost:${dashboard_port}"
+                open "${dashboard_url}"
             elif command -v xdg-open >/dev/null 2>&1; then
-                xdg-open "http://localhost:${dashboard_port}"
+                xdg-open "${dashboard_url}"
             else
-                echo "http://localhost:${dashboard_port}"
+                echo "${dashboard_url}"
             fi
             ;;
         help|--help|-h)
@@ -1417,13 +1451,13 @@ _mec_doctor_run() {
     # ------------------------------------------------------------------
     # 11. Dashboard running
     # ------------------------------------------------------------------
-    local dashboard_port
-    dashboard_port=$(config_get_default "ai.dashboard.port" "4242" 2>/dev/null || echo "4242")
+    local dashboard_url
+    dashboard_url=$(_mec_dashboard_url)
     if docker inspect "$MEC_DASHBOARD_CONTAINER" >/dev/null 2>&1; then
         local dash_state
         dash_state=$(docker inspect --format '{{.State.Status}}' "$MEC_DASHBOARD_CONTAINER" 2>/dev/null)
         if [ "$dash_state" = "running" ]; then
-            _doc_pass "Dashboard: running  (http://localhost:${dashboard_port})"
+            _doc_pass "Dashboard: running  (${dashboard_url})"
         else
             _doc_warn "Dashboard: ${dash_state}  (run 'mec dashboard start')"
         fi

--- a/bin/utils/common.sh
+++ b/bin/utils/common.sh
@@ -312,11 +312,10 @@ run_claude_analysis() {
     fi
 
     # Read Claude execution settings from config
-    local claude_model claude_max_tokens claude_effort_level dashboard_port
+    local claude_model claude_max_tokens claude_effort_level
     claude_model=$(config_get_default "ai.claude.model" "sonnet")
     claude_max_tokens=$(config_get_default "ai.claude.max_output_tokens" "8096")
     claude_effort_level=$(config_get_default "ai.claude.effort_level" "medium")
-    dashboard_port=$(config_get_default "ai.dashboard.port" "4242")
 
     # Compute sidecar path: $MEC_HOME/logs/tool/ts.json -> $MEC_HOME/ai-analyses/tool/ts.json
     local log_dir ai_analyses_dir ai_file
@@ -397,6 +396,32 @@ PYEOF
     fi
 }
 
+# Return the dashboard base URL (e.g. http://localhost:4242).
+# Single source of truth for the port config key and default value.
+# Usage: _mec_dashboard_url
+_mec_dashboard_url() {
+    local port
+    port=$(config_get_default "ai.dashboard.port" "4242")
+    printf 'http://localhost:%s' "$port"
+}
+
+# Print session ID and results URL for an AI analysis.
+# Usage: _mec_ai_notify <log_file> [prefix] [fd]
+# prefix: cosmetic string prepended to each line (e.g. "[mec-ai] "); default: none.
+# fd:     file descriptor to write to (1=stdout, 2=stderr); default: 1.
+_mec_ai_notify() {
+    local log_file="$1" prefix="${2:-}" fd="${3:-1}"
+    local session_id base_url
+    session_id=$(grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$log_file" \
+        | sed 's/.*"session_id"[^"]*"\([^"]*\)".*/\1/')
+    session_id="${session_id:-${LOG_SESSION_ID:-$(basename "$log_file" .json)}}"
+    base_url=$(_mec_dashboard_url)
+
+    printf '%sSession:  %s\n' "$prefix" "$session_id" >&"$fd"
+    printf '%sResults:  %s/sessions/%s\n' "$prefix" "$base_url" "$session_id" >&"$fd"
+    printf '%s          (or: mec ai last)\n' "$prefix" >&"$fd"
+}
+
 # Conditionally trigger AI analysis in the background after a tool run.
 # Guards: only runs when MEC_AI_ENABLED=true, credentials set, images available.
 # Usage: trigger_ai_analysis "path/to/log.json"
@@ -431,19 +456,9 @@ trigger_ai_analysis() {
         return 0
     fi
 
-    local dashboard_port
-    dashboard_port=$(config_get_default "ai.dashboard.port" "4242")
-
-    local session_id
-    session_id=$(grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$log_file" \
-        | sed 's/.*"session_id"[^"]*"\([^"]*\)".*/\1/')
-    session_id="${session_id:-${LOG_SESSION_ID:-$(basename "$log_file" .json)}}"
-
     echo "" >&2
     echo "[mec-ai] Analysis running in background..." >&2
-    echo "[mec-ai] Session:  $session_id" >&2
-    echo "[mec-ai] Results:  http://localhost:${dashboard_port}/sessions/${session_id}" >&2
-    echo "[mec-ai]           (or: mec ai last)" >&2
+    _mec_ai_notify "$log_file" "[mec-ai] "
 
     # Snapshot env vars needed inside the subshell before backgrounding
     local _api_key="${ANTHROPIC_API_KEY:-}"

--- a/services/dashboard/frontend/src/pages/SessionDetailPage.test.js
+++ b/services/dashboard/frontend/src/pages/SessionDetailPage.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SessionDetailPage from './SessionDetailPage.vue'
+
+// Stub child components and dependencies
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { sessionId: 'mec-node-test-1234' } }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+vi.mock('../composables/useWebSocket.js', () => ({
+  useWebSocket: () => ({ onRefresh: () => () => {} }),
+}))
+vi.mock('../components/LogOutput.vue', () => ({
+  default: { template: '<div class="log-output-stub" />' },
+}))
+vi.mock('../components/AiOutput.vue', () => ({
+  default: { template: '<div class="ai-output-stub" />', props: ['content', 'status'] },
+}))
+vi.mock('primevue/tag', () => ({
+  default: { template: '<span class="tag-stub">{{ value }}</span>', props: ['value', 'severity'] },
+}))
+vi.mock('primevue/button', () => ({
+  default: {
+    template: '<button class="btn-stub" @click="$emit(\'click\')"><slot /></button>',
+    emits: ['click'],
+    props: ['icon', 'text', 'rounded', 'size'],
+  },
+}))
+
+function makeSession(overrides = {}) {
+  return {
+    session_id: 'mec-node-test-1234',
+    tool: 'node',
+    timestamp: '2026-01-15T10:00:00.000Z',
+    exit_code: 0,
+    ai_status: 'done',
+    command: 'node --version',
+    cwd: '/tmp',
+    stdout: 'v24.0.0',
+    stderr: '',
+    ai_result: 'Analysis complete.',
+    claude_session_id: '',
+    ai_execution_time_ms: null,
+    ai_tokens_input: null,
+    ai_tokens_output: null,
+    ...overrides,
+  }
+}
+
+async function mountWithSession(session) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => session,
+  })
+  const wrapper = mount(SessionDetailPage, {
+    attachTo: document.body,
+  })
+  // Wait for fetch + reactivity
+  await new Promise((r) => setTimeout(r, 10))
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('SessionDetailPage — AI Time and Tokens meta-bar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows AI time when ai_execution_time_ms is present', async () => {
+    const wrapper = await mountWithSession(makeSession({ ai_execution_time_ms: 5000 }))
+    expect(wrapper.text()).toContain('AI Time')
+    expect(wrapper.text()).toContain('5.0s')
+  })
+
+  it('hides AI time when ai_execution_time_ms is null', async () => {
+    const wrapper = await mountWithSession(makeSession({ ai_execution_time_ms: null }))
+    expect(wrapper.text()).not.toContain('AI Time')
+  })
+
+  it('formats AI time correctly for sub-second values', async () => {
+    const wrapper = await mountWithSession(makeSession({ ai_execution_time_ms: 450 }))
+    expect(wrapper.text()).toContain('0.5s')
+  })
+
+  it('shows token counts when both are present', async () => {
+    const wrapper = await mountWithSession(
+      makeSession({ ai_tokens_input: 100, ai_tokens_output: 50 }),
+    )
+    expect(wrapper.text()).toContain('Tokens')
+    expect(wrapper.text()).toContain('in=100')
+    expect(wrapper.text()).toContain('out=50')
+  })
+
+  it('hides Tokens when both are null', async () => {
+    const wrapper = await mountWithSession(
+      makeSession({ ai_tokens_input: null, ai_tokens_output: null }),
+    )
+    expect(wrapper.text()).not.toContain('Tokens')
+  })
+
+  it('shows Tokens section when only input is present', async () => {
+    const wrapper = await mountWithSession(
+      makeSession({ ai_tokens_input: 200, ai_tokens_output: null }),
+    )
+    expect(wrapper.text()).toContain('Tokens')
+    expect(wrapper.text()).toContain('in=200')
+  })
+})

--- a/services/dashboard/frontend/src/pages/SessionDetailPage.vue
+++ b/services/dashboard/frontend/src/pages/SessionDetailPage.vue
@@ -40,6 +40,14 @@
           <span class="meta-label">AI Status</span>
           <Tag :value="session.ai_status" :severity="aiSeverity(session.ai_status)" />
         </div>
+        <div v-if="session.ai_execution_time_ms != null" class="meta-item">
+          <span class="meta-label">AI Time</span>
+          <span class="meta-value mono">{{ (session.ai_execution_time_ms / 1000).toFixed(1) }}s</span>
+        </div>
+        <div v-if="session.ai_tokens_input != null || session.ai_tokens_output != null" class="meta-item">
+          <span class="meta-label">Tokens</span>
+          <span class="meta-value mono">in={{ session.ai_tokens_input ?? '—' }} • out={{ session.ai_tokens_output ?? '—' }}</span>
+        </div>
         <div v-if="session.ai_status === 'none'" class="meta-item meta-item--wide">
           <span class="meta-label">Run AI Analysis</span>
           <div class="session-id-row">

--- a/services/dashboard/src/sessions.py
+++ b/services/dashboard/src/sessions.py
@@ -194,6 +194,9 @@ class SessionSummary:
     timestamp: str
     exit_code: int | None
     ai_status: str  # "none" | "pending" | "done"
+    ai_execution_time_ms: int | None = None
+    ai_tokens_input: int | None = None
+    ai_tokens_output: int | None = None
 
 
 @dataclass
@@ -301,7 +304,7 @@ def list_sessions(data_root: Path, limit: int = 50) -> dict[str, object]:
         exit_code_raw = execution.get("exit_code")
         exit_code = int(exit_code_raw) if exit_code_raw is not None else None  # type: ignore[arg-type]
         ai_path = _sidecar_path(log_path, data_root)
-        status, _, _claude_id, *_ = _ai_status(ai_path)
+        status, _, _claude_id, exec_time, tok_in, tok_out = _ai_status(ai_path)
         results.append(
             SessionSummary(
                 session_id=str(data.get("session_id", "")),
@@ -309,6 +312,9 @@ def list_sessions(data_root: Path, limit: int = 50) -> dict[str, object]:
                 timestamp=str(execution.get("start_time", data.get("timestamp", ""))),
                 exit_code=exit_code,
                 ai_status=status,
+                ai_execution_time_ms=exec_time,
+                ai_tokens_input=tok_in,
+                ai_tokens_output=tok_out,
             )
         )
     return {"sessions": results, "total": total}

--- a/services/dashboard/tests/test_sessions.py
+++ b/services/dashboard/tests/test_sessions.py
@@ -39,13 +39,25 @@ def _write_log(data_root: Path, tool: str, ts: str, session_id: str, exit_code: 
     return log_path
 
 
-def _write_sidecar(data_root: Path, tool: str, ts: str, result: str = "") -> Path:
+def _write_sidecar(
+    data_root: Path,
+    tool: str,
+    ts: str,
+    result: str = "",
+    execution_time_ms: int | None = None,
+    tokens: dict[str, int] | None = None,
+) -> Path:
     ai_dir = data_root / "ai-analyses" / tool
     ai_dir.mkdir(parents=True, exist_ok=True)
     ai_path = ai_dir / f"{ts}.json"
     analyses = {}
     if result:
-        analyses["abc-123"] = {"timestamp": "2026-03-25T12:00:00Z", "result": result}
+        entry: dict[str, object] = {"timestamp": "2026-03-25T12:00:00Z", "result": result}
+        if execution_time_ms is not None:
+            entry["execution_time_ms"] = execution_time_ms
+        if tokens is not None:
+            entry["tokens"] = tokens
+        analyses["abc-123"] = entry
     ai_path.write_text(json.dumps({"log_session_id": "x", "analyses": analyses}))
     return ai_path
 
@@ -91,6 +103,21 @@ class TestListSessions:
         _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-1")
         _write_sidecar(data_root, "npm", "2026-03-25_12-00-00", result="All good.")
         assert list_sessions(data_root)["sessions"][0].ai_status == "done"
+
+    def test_ai_time_and_tokens_included_in_list(self, data_root: Path) -> None:
+        _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-1")
+        _write_sidecar(
+            data_root,
+            "npm",
+            "2026-03-25_12-00-00",
+            result="All good.",
+            execution_time_ms=5000,
+            tokens={"input": 100, "output": 50},
+        )
+        session = list_sessions(data_root)["sessions"][0]
+        assert session.ai_execution_time_ms == 5000
+        assert session.ai_tokens_input == 100
+        assert session.ai_tokens_output == 50
 
     def test_sorted_newest_first(self, data_root: Path) -> None:
         _write_log(data_root, "npm", "2026-03-25_10-00-00", "mec-npm-old")

--- a/tests/unit/test-dashboard.bats
+++ b/tests/unit/test-dashboard.bats
@@ -131,7 +131,7 @@ teardown() {
 
 @test "mec dashboard open falls back to echo URL when no browser is found" {
     # Verify the fallback else branch exists in the script
-    grep -q 'echo.*http://localhost' "$BASEDIR/bin/mec"
+    grep -q 'echo.*dashboard_url' "$BASEDIR/bin/mec"
 }
 
 @test "mec dashboard open supports open command for macOS" {


### PR DESCRIPTION
## Summary

- **`mec ai last` / `mec ai show`**: now shows AI execution time (`AI time: X.Xs`) and token counts (`Tokens: in=N • out=N`) after the AI status line when analysis is complete; gracefully absent for sessions without analysis or older sidecars
- **`mec ai logs`**: new `AI TIME` column in the table; `done` rows show formatted wall-clock time (e.g. `12.5s`); `pending`/`none` rows show `--`
- **Dashboard sessions list**: `AI Time` column now populated from the list endpoint (was missing — `SessionSummary` lacked the fields)
- **Dashboard session detail**: two new meta-bar items — `AI Time` and `Tokens` — appear when the fields are populated; hidden when null
- **`mec ai analyze` is now async**: fires analysis in the background and returns immediately, consistent with auto-analysis behavior; prints session ID and results URL before backgrounding
- **`_mec_ai_notify()` shared helper** in `common.sh`: extracts session ID + dashboard URL printing into a reusable function; `prefix` (cosmetic) and `fd` (output destination) are independent parameters
- **`_mec_dashboard_url()` helper** in `common.sh`: single source of truth for the dashboard base URL (`http://localhost:<port>`); all call sites in `bin/mec` and `common.sh` use it instead of re-reading the config key inline
- **ai-service Docker image rebuilt**: production image was stale (predated token-writing feature from PR #65); `tokens: {input, output}` now correctly written to sidecars

All TUI extraction uses `grep`/`sed` on the pretty-printed sidecar JSON, consistent with the existing field extraction pattern. No `mec-python` or `python3` dependency added.

## Test plan

- [x] `cd services/dashboard/frontend && npm test` — all 30 tests pass (6 new)
- [x] Python dashboard tests (34) pass with local source mounted
- [x] `bash -n bin/mec` — syntax check passes
- [x] Manual: `./bin/mec ai analyze <session-id>` returns immediately with session ID and results URL
- [x] Manual: `./bin/mec ai show mec-yarn-1774632839` → shows `AI time: 45.7s` and `Tokens: in=3 • out=183`
- [x] Manual: `./bin/mec ai logs` → `AI TIME` column visible and correctly aligned; done rows show time
- [x] Manual: dashboard session detail page → meta-bar shows AI Time and Tokens for analyzed sessions; absent for unanalyzed

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)