### PR TITLE
fix(dashboard): suppress RouterLink and v-tooltip Vue warnings in test env (#119)

### DIFF
--- a/services/dashboard/frontend/src/vitest.setup.js
+++ b/services/dashboard/frontend/src/vitest.setup.js
@@ -1,0 +1,13 @@
+import { config } from '@vue/test-utils'
+
+// Stub RouterLink globally so tests don't need a full router
+config.global.stubs = {
+  ...config.global.stubs,
+  RouterLink: { template: '<a><slot /></a>' },
+}
+
+// Register v-tooltip as a no-op directive globally
+config.global.directives = {
+  ...config.global.directives,
+  tooltip: {},
+}

--- a/services/dashboard/frontend/vite.config.js
+++ b/services/dashboard/frontend/vite.config.js
@@ -27,5 +27,6 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.test.js'],
     exclude: ['tests/e2e/**', 'node_modules/**'],
+    setupFiles: ['src/vitest.setup.js'],
   },
 })


### PR DESCRIPTION
## Summary

- Add `src/vitest.setup.js` with global stubs for `RouterLink` and `v-tooltip` directive
- Register setup file in `vite.config.js` via `setupFiles`

## Changes

- **Create:** `services/dashboard/frontend/src/vitest.setup.js` — global `@vue/test-utils` config stubs
- **Modify:** `services/dashboard/frontend/vite.config.js` — add `setupFiles` to test config

## Test plan

- [ ] `cd services/dashboard/frontend && npm test` — all tests pass, no Vue component/directive resolution warnings

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)