### PR TITLE
feat(dashboard): add copy button to Working Dir and Command fields in Session Detail (#120)

### DIFF
--- a/services/dashboard/frontend/src/pages/SessionDetailPage.test.js
+++ b/services/dashboard/frontend/src/pages/SessionDetailPage.test.js
@@ -107,3 +107,14 @@ describe('SessionDetailPage — AI Time and Tokens meta-bar', () => {
     expect(wrapper.text()).toContain('in=200')
   })
 })
+
+describe('SessionDetailPage — Working Dir copy button', () => {
+  it('shows copy button next to cwd when cwd is present', async () => {
+    const wrapper = await mountWithSession(makeSession({ cwd: '/home/user/myproject' }))
+    expect(wrapper.text()).toContain('Working Dir')
+    expect(wrapper.text()).toContain('/home/user/myproject')
+    // Should have a copy button in the cwd row
+    const buttons = wrapper.findAll('.btn-stub')
+    expect(buttons.length).toBeGreaterThan(0)
+  })
+})

--- a/services/dashboard/frontend/src/pages/SessionDetailPage.vue
+++ b/services/dashboard/frontend/src/pages/SessionDetailPage.vue
@@ -80,7 +80,18 @@
         </div>
         <div v-if="session.cwd" class="meta-item meta-item--wide">
           <span class="meta-label">Working Dir</span>
-          <span class="meta-value mono" style="font-size: 11px; color: var(--mec-text-dim);">{{ session.cwd }}</span>
+          <div class="session-id-row">
+            <span class="meta-value mono" style="font-size: 11px; color: var(--mec-text-dim);">{{ session.cwd }}</span>
+            <Button
+              icon="pi pi-copy"
+              text
+              rounded
+              size="small"
+              style="color: var(--mec-text-faint); width: 24px; height: 24px;"
+              v-tooltip="copiedCwd ? 'Copied!' : 'Copy path'"
+              @click="copyCwd"
+            />
+          </div>
         </div>
         <div v-if="session.claude_session_id" class="meta-item meta-item--wide">
           <span class="meta-label">Resume AI</span>
@@ -103,6 +114,15 @@
       <div v-if="session.command" class="command-bar">
         <span class="command-prompt">$</span>
         <span class="command-text">{{ session.command }}</span>
+        <Button
+          icon="pi pi-copy"
+          text
+          rounded
+          size="small"
+          style="color: var(--mec-text-faint); width: 24px; height: 24px; margin-left: auto; flex-shrink: 0;"
+          v-tooltip="copiedCommand ? 'Copied!' : 'Copy command'"
+          @click="copyCommand"
+        />
       </div>
 
       <!-- Two-panel layout -->
@@ -140,6 +160,8 @@ const notFound = ref(false)
 const copiedId = ref(false)
 const copiedResume = ref(false)
 const copiedAnalyze = ref(false)
+const copiedCwd = ref(false)
+const copiedCommand = ref(false)
 const { onRefresh } = useWebSocket()
 
 async function fetchSession() {
@@ -196,6 +218,22 @@ async function copyAnalyze() {
     await navigator.clipboard.writeText(`mec ai analyze ${session.value?.session_id}`)
     copiedAnalyze.value = true
     setTimeout(() => { copiedAnalyze.value = false }, 2000)
+  } catch { /* noop */ }
+}
+
+async function copyCommand() {
+  try {
+    await navigator.clipboard.writeText(session.value?.command)
+    copiedCommand.value = true
+    setTimeout(() => { copiedCommand.value = false }, 2000)
+  } catch { /* noop */ }
+}
+
+async function copyCwd() {
+  try {
+    await navigator.clipboard.writeText(session.value?.cwd)
+    copiedCwd.value = true
+    setTimeout(() => { copiedCwd.value = false }, 2000)
   } catch { /* noop */ }
 }
 </script>


### PR DESCRIPTION
## Summary

- Add copy button to the **Working Dir** (`cwd`) field in the meta bar
- Add copy button to the **Command** bar (the `$ <command>` section below the meta bar)
- Both match the existing copy button pattern (Session ID, Resume AI, Run AI Analysis)
- Show "Copied!" tooltip for 2s after click

## Changes

- **Modify:** `services/dashboard/frontend/src/pages/SessionDetailPage.vue` — template + refs (`copiedCwd`, `copiedCommand`) + functions (`copyCwd`, `copyCommand`)
- **Modify:** `services/dashboard/frontend/src/pages/SessionDetailPage.test.js` — new test for cwd copy button presence

## Test plan

- [ ] `cd services/dashboard/frontend && npm test` — all 31 tests pass
- [ ] Session Detail page shows copy button next to Working Dir
- [ ] Session Detail page shows copy button in Command bar (right-aligned)
- [ ] Both copy buttons show "Copied!" tooltip for 2s after click

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)