### PR TITLE
fix(dashboard): include command and cwd in SessionSummary for search filtering (#121)

### DIFF
--- a/services/dashboard/src/sessions.py
+++ b/services/dashboard/src/sessions.py
@@ -197,6 +197,8 @@ class SessionSummary:
     ai_execution_time_ms: int | None = None
     ai_tokens_input: int | None = None
     ai_tokens_output: int | None = None
+    command: str = ""
+    cwd: str = ""
 
 
 @dataclass
@@ -315,6 +317,8 @@ def list_sessions(data_root: Path, limit: int = 50) -> dict[str, object]:
                 ai_execution_time_ms=exec_time,
                 ai_tokens_input=tok_in,
                 ai_tokens_output=tok_out,
+                command=str(data.get("command", "")),
+                cwd=str(data.get("cwd", "")),
             )
         )
     return {"sessions": results, "total": total}

--- a/services/dashboard/tests/test_sessions.py
+++ b/services/dashboard/tests/test_sessions.py
@@ -160,6 +160,32 @@ class TestListSessions:
         sessions = list_sessions(data_root)["sessions"]
         assert all(s.session_id == "mec-npm-1" for s in sessions)
 
+    def test_command_included_in_list(self, data_root: Path) -> None:
+        """command field should be included in the list view for search filtering."""
+        _write_log(data_root, "npm", "2026-03-25_12-00-00", "mec-npm-1")
+        session = list_sessions(data_root)["sessions"][0]
+        assert session.command == "npm --version"
+
+    def test_cwd_included_in_list(self, data_root: Path) -> None:
+        """cwd field should be included in the list view for search filtering."""
+        log_dir = data_root / "logs" / "node"
+        log_dir.mkdir(parents=True)
+        (log_dir / "2026-01-01_00-00-01.json").write_text(
+            json.dumps(
+                {
+                    "session_id": "mec-node-cwd",
+                    "tool": "node",
+                    "cwd": "/home/user/myproject",
+                    "command": "node test.js",
+                    "execution": {"exit_code": 0, "start_time": "2026-01-01T00:00:01Z"},
+                    "output": {"stdout": "", "stderr": ""},
+                }
+            )
+        )
+        session = list_sessions(data_root)["sessions"][0]
+        assert session.cwd == "/home/user/myproject"
+        assert session.command == "node test.js"
+
 
 class TestGetSession:
     """Tests for get_session()."""


### PR DESCRIPTION
## Summary

Search Sessions was only matching on `tool` and `session_id` because `command` and `cwd` weren't included in the `SessionSummary` API response. The client-side filter already searched these fields correctly — it just received empty strings from the backend.

## Root Cause

`SessionSummary` (list view model) was missing `command` and `cwd` fields. `SessionDetail` (full view) had them, so the detail page worked fine.

## Changes

- **Modify:** `services/dashboard/src/sessions.py` — add `command` and `cwd` to `SessionSummary`; populate them in `list_sessions()`
- **Modify:** `services/dashboard/tests/test_sessions.py` — add `test_command_included_in_list` and `test_cwd_included_in_list`

## Test plan

- [x] `cd services/dashboard && python -m pytest tests/ -v` — 36 tests pass
- [x] Searching "test" in Sessions page returns sessions where command contains "test" (e.g. `npm test`)
- [x] Searching a path segment returns sessions run in that directory

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)