### PR TITLE
feat: display UTC timezone indicator on session timestamps (#125)

### DIFF
--- a/bin/mec
+++ b/bin/mec
@@ -399,7 +399,7 @@ print(items[-1][0] if items else '', end='')
 
     echo "Session:   ${session_id:-unknown}"
     echo "Tool:      ${tool:-unknown}"
-    echo "Timestamp: ${start_time:-unknown}"
+    echo "Timestamp: ${start_time:-unknown} UTC"
     echo "Exit code: ${exit_code:-unknown}"
     echo "AI status: $ai_status"
     if [ -n "$exec_time_ms" ]; then
@@ -507,8 +507,8 @@ _mec_ai_logs() {
         return 0
     fi
 
-    printf "%-21s %-12s %-6s %-10s %-8s %s\n" "TIMESTAMP" "TOOL" "EXIT" "AI" "AI TIME" "SESSION ID"
-    printf "%-21s %-12s %-6s %-10s %-8s %s\n" "---------------------" "------------" "------" "----------" "--------" "----------"
+    printf "%-25s %-12s %-6s %-10s %-8s %s\n" "TIMESTAMP (UTC)" "TOOL" "EXIT" "AI" "AI TIME" "SESSION ID"
+    printf "%-25s %-12s %-6s %-10s %-8s %s\n" "-------------------------" "------------" "------" "----------" "--------" "----------"
 
     echo "$log_files" | while IFS= read -r log_file; do
         [ -f "$log_file" ] || continue
@@ -522,6 +522,7 @@ _mec_ai_logs() {
         local ts_display
         ts_display=$(echo "$start_time" | sed 's/T/ /; s/\.[0-9]*//' | cut -c1-19)
         [ -z "$ts_display" ] && ts_display="unknown"
+        ts_display="${ts_display} UTC"
 
         # Derive sidecar path
         local ai_file
@@ -549,7 +550,7 @@ _mec_ai_logs() {
             fi
         fi
 
-        printf "%-21s %-12s %-6s %-10s %-8s %s\n" "$ts_display" "${tool:-?}" "${exit_code:-?}" "$ai_status" "$ai_time" "${session_id:-?}"
+        printf "%-25s %-12s %-6s %-10s %-8s %s\n" "$ts_display" "${tool:-?}" "${exit_code:-?}" "$ai_status" "$ai_time" "${session_id:-?}"
     done
 }
 

--- a/services/dashboard/frontend/src/components/SessionTable.vue
+++ b/services/dashboard/frontend/src/components/SessionTable.vue
@@ -26,7 +26,7 @@
       <div class="table-loading">Loading sessions…</div>
     </template>
 
-    <Column field="timestamp" header="Timestamp" sortable>
+    <Column field="timestamp" header="Timestamp (UTC)" sortable>
       <template #body="{ data }">
         <span class="mono" style="font-size: 12px; color: var(--mec-text-dim);">{{ fmtTs(data.timestamp) }}</span>
       </template>
@@ -93,7 +93,7 @@ const emit = defineEmits(['row-click'])
 
 function fmtTs(ts) {
   if (!ts) return '—'
-  return ts.replace('T', ' ').replace(/\.\d+Z?$/, '').replace('Z', '')
+  return ts.replace('T', ' ').replace(/\.\d+Z?$/, '').replace(/Z$/, '') + ' UTC'
 }
 
 function aiSeverity(status) {

--- a/services/dashboard/frontend/src/pages/SessionDetailPage.vue
+++ b/services/dashboard/frontend/src/pages/SessionDetailPage.vue
@@ -188,7 +188,7 @@ onMounted(() => {
 
 function fmtTs(ts) {
   if (!ts) return '—'
-  return ts.replace('T', ' ').replace(/\.\d+Z?$/, '').replace('Z', '')
+  return ts.replace('T', ' ').replace(/\.\d+Z?$/, '').replace(/Z$/, '') + ' UTC'
 }
 
 function aiSeverity(status) {


### PR DESCRIPTION
## Summary

Session logs are generated inside Docker containers (UTC timezone). This makes it explicit by appending `UTC` to all displayed timestamps.

## Changes

- **`services/dashboard/frontend/src/pages/SessionDetailPage.vue`** — `fmtTs()` appends ` UTC` instead of stripping `Z`
- **`services/dashboard/frontend/src/components/SessionTable.vue`** — column header `Timestamp` → `Timestamp (UTC)`; same `fmtTs()` fix
- **`bin/mec`** — `mec ai last` timestamp line appends ` UTC`; `mec ai logs` column header `TIMESTAMP` → `TIMESTAMP (UTC)` with widened format

## Test plan

- [x] `cd services/dashboard/frontend && npm test` — all 31 tests pass
- [x] `mec ai logs` header shows `TIMESTAMP (UTC)`
- [x] `mec ai last` timestamp shows ` UTC` suffix
- [x] Dashboard Sessions list column header shows `Timestamp (UTC)`
- [x] Dashboard Session Detail meta bar timestamp shows ` UTC` suffix

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)