### PR TITLE
fix: correct node symlink integration test assertion (v24 → v22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ data/
 
 # Claude - ignoring local settings
 .claude/*.local.json
+.claude/worktrees/
 .worktrees/

--- a/tests/integration/test-symlink-execution.bats
+++ b/tests/integration/test-symlink-execution.bats
@@ -16,7 +16,7 @@ teardown() {
     ln -sf "$BASEDIR/bin/node" "$SYMLINK_DIR/node"
     run "$SYMLINK_DIR/node" --version
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "v24" ]]
+    [[ "$output" =~ "v22" ]]
 }
 
 @test "npm works when executed via symlink" {


### PR DESCRIPTION
## Summary

- Fixes failing integration test `node works when executed via symlink` on `main`
- `bin/node` uses `MEC_IMAGE_NODE` which defaults to `node:22-alpine` (`config/images.conf:22`), but the test was asserting `v24` — making it always fail
- Also includes `chore: ignore worktrees folder` (`.gitignore` addition for `.claude/worktrees/`)

## Root Cause

```bats
# Before (wrong — bin/node runs node:22-alpine)
[[ "$output" =~ "v24" ]]

# After (correct)
[[ "$output" =~ "v22" ]]
```

## Test plan

- [ ] Integration test job passes on this PR
- [ ] `not ok 13 node works when executed via symlink` no longer appears