### PR TITLE
ci: adjust build schedule to 1 AM and add standalone Trivy scan

### DIFF
--- a/.github/workflows/docker-build-all.yml
+++ b/.github/workflows/docker-build-all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - rc-v1-alpha
     paths:
       - 'docker/**'
       - 'services/**'
@@ -12,8 +11,8 @@ on:
   release:
     types: [published]
   schedule:
-    # Run weekly on Sundays at 2 AM UTC
-    - cron: '0 2 * * 0'
+    # Run weekly on Sundays at 1 AM UTC
+    - cron: '0 1 * * 0'
 
 jobs:
   # Single approval gate — all images publish only after this is approved

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,57 @@
+name: Security Scan
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'   # Sunday 2:00 AM UTC
+  workflow_dispatch:
+
+jobs:
+  scan:
+    name: Trivy — ${{ matrix.tool }}
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - ai-service
+          - aws-sso-cred
+          - claude
+          - config-service
+          - dashboard
+          - playwright
+          - serverless
+          - speedtest
+          - yarn-berry
+          - yarn-plus
+
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          image-ref: ghcr.io/my-ez-cli/${{ matrix.tool }}:latest
+          format: 'sarif'
+          output: trivy-results-${{ matrix.tool }}.sarif
+
+      - name: Upload Trivy results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results-${{ matrix.tool }}.sarif
+          category: trivy-${{ matrix.tool }}
+
+  summary:
+    name: Security Scan Summary
+    runs-on: ubuntu-latest
+    needs: scan
+    if: always()
+    steps:
+      - name: Summary
+        run: |
+          echo "## Security Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy scanned all 10 GHCR images. Check the Security tab for findings." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Status | Note |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Scan job result: ${{ needs.scan.result }} | See individual job logs for details |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Shifts the weekly `docker-build-all.yml` rebuild from 2:00 AM → **1:00 AM UTC** (Sunday)
- Removes the stale `rc-v1-alpha` push trigger from `docker-build-all.yml` (branch no longer exists)
- Adds a new **`security-scan.yml`** workflow: standalone Trivy scan at **2:00 AM UTC** (Sunday)
  - Matrix over all 10 GHCR images without requiring a full rebuild
  - Uploads SARIF results to GitHub Security tab with per-tool category labels
  - Also triggerable via `workflow_dispatch` for manual runs

## Motivation

Trivy was previously only embedded in individual build workflows — no standalone scan existed. This adds a dedicated weekly scan that catches newly disclosed CVEs in already-published images between rebuild cycles.

## Test plan

- [ ] Trigger `security-scan.yml` via `workflow_dispatch` and verify all 10 matrix jobs run
- [ ] Verify SARIF results appear in the Security tab for each tool
- [ ] Confirm `docker-build-all.yml` no longer references `rc-v1-alpha`
- [ ] Verify cron change: `0 1 * * 0` in `docker-build-all.yml`

Closes #151