### PR TITLE
docs: add workflow status and project badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # My Ez CLI
 
 [![CI](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/test.yml/badge.svg)](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/test.yml)
-[![Docker Builds](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/docker-build-dashboard.yml/badge.svg)](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/docker-build-dashboard.yml)
+[![Build All](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/docker-build-all.yml/badge.svg)](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/docker-build-all.yml)
+[![Security Scan](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/security-scan.yml/badge.svg)](https://github.com/DavidCardoso/my-ez-cli/actions/workflows/security-scan.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GitHub release](https://img.shields.io/github/v/release/DavidCardoso/my-ez-cli)](https://github.com/DavidCardoso/my-ez-cli/releases)
+[![GitHub issues](https://img.shields.io/github/issues/DavidCardoso/my-ez-cli)](https://github.com/DavidCardoso/my-ez-cli/issues)
 
 
 CLI tools over Docker — managed by `mec`.


### PR DESCRIPTION
## Summary

Replaces the two existing badges with a fuller set that better represents project health and deployment status:

- **CI** — kept (test.yml)
- **Build All** — replaces dashboard-only badge with the umbrella `docker-build-all.yml`
- **Security Scan** — new badge for the standalone Trivy workflow (from PR #154)
- **License: MIT** — static shields.io badge
- **GitHub release** — dynamic badge showing latest release tag
- **GitHub issues** — dynamic badge showing open issue count

## Test plan

- [ ] Verify all 6 badges render correctly on the GitHub README
- [ ] Verify Build All badge reflects actual `docker-build-all.yml` run status
- [ ] Verify Security Scan badge reflects `security-scan.yml` run status

Closes #146