### PR TITLE
docs: rename DOCKER_HUB.md to CONTAINER_REGISTRY.md and update for GHCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ First release candidate for v1.0.0. Combines Phase 1 (Docker tooling foundation)
 - Docker Hub migration: all custom images moved to `davidcardoso/my-ez-cli` repository
 - Container naming (`mec-{tool}-{timestamp}`) and labeling (`com.my-ez-cli.*`) across all bin scripts
 - GitHub Actions CI/CD workflows for multi-platform Docker image builds
-- Documentation: `docs/SETUP.md`, `docs/DOCKER_HUB.md`, `tests/README.md`
+- Documentation: `docs/SETUP.md`, `docs/CONTAINER_REGISTRY.md`, `tests/README.md`
 
 #### Phase 2 — AI Integration
 - `bin/claude` wrapper script + `docker/claude/Dockerfile` (Claude Code CLI in Docker)

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ For detailed AI documentation, see [docs/AI_INTEGRATION.md](./docs/AI_INTEGRATIO
 - **[docs/ROADMAP.md](./docs/ROADMAP.md)** — Phase status and future plans
 - **[docs/CODE_STANDARDS.md](./docs/CODE_STANDARDS.md)** — Python code standards (type hints, error handling, logging)
 - **[docs/LOG_FORMAT.md](./docs/LOG_FORMAT.md)** — JSON log schema, sidecar files, rotation
-- **[docs/DOCKER_HUB.md](./docs/DOCKER_HUB.md)** — Docker Hub images, CI/CD workflows, GitHub Secrets
+- **[docs/CONTAINER_REGISTRY.md](./docs/CONTAINER_REGISTRY.md)** — Container registry images, CI/CD workflows, GitHub Secrets
 - **[tests/README.md](./tests/README.md)** — Testing framework, writing and running tests
 - **[CONTRIBUTING.md](./CONTRIBUTING.md)** — Contribution guidelines
 - **[CHANGELOG.md](./CHANGELOG.md)** — Release history

--- a/docs/CONTAINER_REGISTRY.md
+++ b/docs/CONTAINER_REGISTRY.md
@@ -1,4 +1,4 @@
-# GitHub Container Registry Setup
+# GitHub Container Registry (GHCR)
 
 My Ez CLI uses GitHub Container Registry (`ghcr.io`) to host all custom Docker images for the project. This document explains the setup, structure, and maintenance of these images.
 
@@ -15,6 +15,9 @@ All custom Docker images are published to per-tool repositories under the `ghcr.
 | AI Service | `ghcr.io/my-ez-cli/ai-service:latest` | amd64, arm64 | `.github/workflows/docker-build-ai-service.yml` |
 | AWS SSO Cred | `ghcr.io/my-ez-cli/aws-sso-cred:latest` | amd64, arm64 | `.github/workflows/docker-build-aws-sso-cred.yml` |
 | Claude Code | `ghcr.io/my-ez-cli/claude:latest` | amd64, arm64 | `.github/workflows/docker-build-claude.yml` |
+| Config Service | `ghcr.io/my-ez-cli/config-service:latest` | amd64, arm64 | `.github/workflows/docker-build-config-service.yml` |
+| Dashboard | `ghcr.io/my-ez-cli/dashboard:latest` | amd64, arm64 | `.github/workflows/docker-build-dashboard.yml` |
+| Playwright | `ghcr.io/my-ez-cli/playwright:latest` | amd64, arm64 | `.github/workflows/docker-build-playwright.yml` |
 | Serverless | `ghcr.io/my-ez-cli/serverless:latest` | amd64, arm64 | `.github/workflows/docker-build-serverless.yml` |
 | Speedtest | `ghcr.io/my-ez-cli/speedtest:latest` | amd64, arm64 | `.github/workflows/docker-build-speedtest.yml` |
 | Yarn Berry | `ghcr.io/my-ez-cli/yarn-berry:latest` | amd64, arm64 | `.github/workflows/docker-build-yarn-berry.yml` |
@@ -239,27 +242,6 @@ echo $GHCR_TOKEN | docker login ghcr.io -u <your-github-username> --password-std
 ```yaml
 platforms: linux/amd64,linux/arm64
 ```
-
-## Migration from Docker Hub
-
-Previous setup used Docker Hub (`davidcardoso/my-ez-cli`). All images have been migrated to GitHub Container Registry.
-
-### Old vs New Images
-
-| Old (Docker Hub) | New (ghcr.io) |
-|------------------|---------------|
-| `davidcardoso/my-ez-cli:aws-sso-cred-latest` | `ghcr.io/my-ez-cli/aws-sso-cred:latest` |
-| `davidcardoso/my-ez-cli:serverless-latest` | `ghcr.io/my-ez-cli/serverless:latest` |
-| `davidcardoso/my-ez-cli:speedtest-latest` | `ghcr.io/my-ez-cli/speedtest:latest` |
-| `davidcardoso/my-ez-cli:yarn-berry-latest` | `ghcr.io/my-ez-cli/yarn-berry:latest` |
-| `davidcardoso/my-ez-cli:yarn-plus-latest` | `ghcr.io/my-ez-cli/yarn-plus:latest` |
-| `davidcardoso/my-ez-cli:dashboard-latest` | `ghcr.io/my-ez-cli/dashboard:latest` |
-| `davidcardoso/my-ez-cli:config-service-latest` | `ghcr.io/my-ez-cli/config-service:latest` |
-| `davidcardoso/my-ez-cli:ai-service-latest` | `ghcr.io/my-ez-cli/ai-service:latest` |
-| `davidcardoso/my-ez-cli:claude-latest` | `ghcr.io/my-ez-cli/claude:latest` |
-| `davidcardoso/my-ez-cli:playwright-latest` | `ghcr.io/my-ez-cli/playwright:latest` |
-
-**Note**: Old images on Docker Hub are deprecated and will not receive updates. Run `mec <tool> pull` or `docker pull ghcr.io/my-ez-cli/<tool>:latest` to update.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Renames `docs/DOCKER_HUB.md` → `docs/CONTAINER_REGISTRY.md` (migration to GHCR is complete — #140, #92 closed)
- Updates H1 to "GitHub Container Registry (GHCR)"
- Adds 3 missing images to the Available Images table: **Dashboard**, **Config Service**, **Playwright** (table now shows all 10)
- Removes the "Migration from Docker Hub" section (historical, no longer needed)
- Updates `README.md` link to point to `CONTAINER_REGISTRY.md` with updated link text
- Updates `CHANGELOG.md` archive reference to use the new filename

## Test plan

- [ ] `docs/DOCKER_HUB.md` does not exist
- [ ] `docs/CONTAINER_REGISTRY.md` exists with all 10 images in the table
- [ ] `README.md` link resolves to `CONTAINER_REGISTRY.md`

Closes #149