### PR TITLE
ci: add CodeQL, OSSF Scorecard, ShellCheck, Hadolint, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,113 @@
+version: 2
+updates:
+  # Python (Poetry) — AI service
+  - package-ecosystem: "pip"
+    directory: "/services/ai"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Python (Poetry) — Dashboard service
+  - package-ecosystem: "pip"
+    directory: "/services/dashboard"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # npm — Dashboard frontend (Vue 3)
+  - package-ecosystem: "npm"
+    directory: "/services/dashboard/frontend"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — ai-service
+  - package-ecosystem: "docker"
+    directory: "/docker/ai-service"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — aws-sso-cred
+  - package-ecosystem: "docker"
+    directory: "/docker/aws-sso-cred"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — claude
+  - package-ecosystem: "docker"
+    directory: "/docker/claude"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — config-service
+  - package-ecosystem: "docker"
+    directory: "/docker/config-service"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — dashboard
+  - package-ecosystem: "docker"
+    directory: "/docker/dashboard"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — playwright
+  - package-ecosystem: "docker"
+    directory: "/docker/playwright"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — serverless
+  - package-ecosystem: "docker"
+    directory: "/docker/serverless"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — speedtest
+  - package-ecosystem: "docker"
+    directory: "/docker/speedtest"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — yarn-berry
+  - package-ecosystem: "docker"
+    directory: "/docker/yarn-berry"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+
+  # Docker base images — yarn-plus
+  - package-ecosystem: "docker"
+    directory: "/docker/yarn-plus"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly on Wednesday at 3 AM UTC
+    - cron: '0 3 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,17 +28,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,70 @@
+name: Hadolint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docker/**'
+
+jobs:
+  hadolint:
+    name: Lint Dockerfiles
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint docker/ai-service/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/ai-service/Dockerfile
+
+      - name: Lint docker/aws-sso-cred/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/aws-sso-cred/Dockerfile
+
+      - name: Lint docker/claude/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/claude/Dockerfile
+
+      - name: Lint docker/config-service/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/config-service/Dockerfile
+
+      - name: Lint docker/dashboard/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/dashboard/Dockerfile
+
+      - name: Lint docker/playwright/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/playwright/Dockerfile
+
+      - name: Lint docker/serverless/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/serverless/Dockerfile
+
+      - name: Lint docker/speedtest/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/speedtest/Dockerfile
+
+      - name: Lint docker/yarn-berry/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/yarn-berry/Dockerfile
+
+      - name: Lint docker/yarn-plus/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/yarn-plus/Dockerfile

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -17,54 +17,54 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Lint docker/ai-service/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/ai-service/Dockerfile
 
       - name: Lint docker/aws-sso-cred/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/aws-sso-cred/Dockerfile
 
       - name: Lint docker/claude/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/claude/Dockerfile
 
       - name: Lint docker/config-service/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/config-service/Dockerfile
 
       - name: Lint docker/dashboard/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/dashboard/Dockerfile
 
       - name: Lint docker/playwright/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/playwright/Dockerfile
 
       - name: Lint docker/serverless/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/serverless/Dockerfile
 
       - name: Lint docker/speedtest/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/speedtest/Dockerfile
 
       - name: Lint docker/yarn-berry/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/yarn-berry/Dockerfile
 
       - name: Lint docker/yarn-plus/Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/yarn-plus/Dockerfile

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,38 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly on Sunday at 3 AM UTC
+    - cron: '0 3 * * 0'
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: scorecard-results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,18 +21,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Run OSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: scorecard-results.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,14 +28,14 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/my-ez-cli/${{ matrix.tool }}:latest
           format: 'sarif'
           output: trivy-results-${{ matrix.tool }}.sarif
 
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results-${{ matrix.tool }}.sarif
           category: trivy-${{ matrix.tool }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run ShellCheck on bin/
         uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,24 @@
+name: ShellCheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck on bin/
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: './bin'
+          severity: warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Pre-commit hooks for My Ez CLI AI Service
+# Pre-commit hooks for My Ez CLI
 # Install: pre-commit install
 # Run manually: pre-commit run --all-files
 # Update hooks: pre-commit autoupdate
@@ -80,7 +80,15 @@ repos:
       - id: python-check-blanket-type-ignore
       - id: python-use-type-annotations
 
-# Configure pre-commit to run faster
+  # ShellCheck — static analysis for shell scripts
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        args: [--severity=warning]
+        files: ^bin/
+
   # Local test suite hooks — run conditionally based on changed files
   - repo: local
     hooks:

--- a/bin/aws-saml-okta
+++ b/bin/aws-saml-okta
@@ -279,14 +279,13 @@ okta_mfa_verify() {
         esac
     done <<< "$factors"
 
-    local factor_id factor_type verify_url
+    local factor_type verify_url
 
     # Auto-select if preferred_factor_type is configured
     if [ -n "$preferred_factor_type" ]; then
         case "$preferred_factor_type" in
             push)
                 if [ -n "$push_line" ]; then
-                    factor_id=$(echo "$push_line" | cut -d'|' -f1)
                     factor_type="push"
                     verify_url=$(echo "$push_line" | cut -d'|' -f4)
                     echo "Auto-selecting push MFA (from config)." >/dev/tty
@@ -294,7 +293,6 @@ okta_mfa_verify() {
                 ;;
             token:software:totp)
                 if [ -n "$totp_line" ]; then
-                    factor_id=$(echo "$totp_line" | cut -d'|' -f1)
                     factor_type="token:software:totp"
                     verify_url=$(echo "$totp_line" | cut -d'|' -f4)
                     echo "Auto-selecting TOTP MFA (from config)." >/dev/tty
@@ -313,20 +311,16 @@ okta_mfa_verify() {
             mfa_choice="${mfa_choice:-1}"
 
             if [ "$mfa_choice" = "2" ]; then
-                factor_id=$(echo "$totp_line" | cut -d'|' -f1)
                 factor_type="token:software:totp"
                 verify_url=$(echo "$totp_line" | cut -d'|' -f4)
             else
-                factor_id=$(echo "$push_line" | cut -d'|' -f1)
                 factor_type="push"
                 verify_url=$(echo "$push_line" | cut -d'|' -f4)
             fi
         elif [ -n "$totp_line" ]; then
-            factor_id=$(echo "$totp_line" | cut -d'|' -f1)
             factor_type="token:software:totp"
             verify_url=$(echo "$totp_line" | cut -d'|' -f4)
         elif [ -n "$push_line" ]; then
-            factor_id=$(echo "$push_line" | cut -d'|' -f1)
             factor_type="push"
             verify_url=$(echo "$push_line" | cut -d'|' -f4)
         else
@@ -399,7 +393,7 @@ okta_fetch_saml() {
 
     local cookie_jar
     cookie_jar=$(mktemp)
-    trap "rm -f '$cookie_jar'" RETURN
+    trap 'rm -f "$cookie_jar"' RETURN
 
     # Try ?sessionToken= first (standard Okta param), fall back to ?onetimetoken=
     local html_response
@@ -682,7 +676,7 @@ EOF
     echo "Fetching SAML assertion..."
     local assertion_file
     assertion_file=$(mktemp)
-    trap "rm -f '$assertion_file'" EXIT
+    trap 'rm -f "$assertion_file"' EXIT
     okta_fetch_saml "$saml_url" "$session_token" "$assertion_file"
     if [ ! -s "$assertion_file" ]; then
         echo "Error: Failed to fetch SAML assertion." >&2

--- a/bin/aws-sso
+++ b/bin/aws-sso
@@ -7,7 +7,6 @@ MEC_BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 . "${MEC_BASE_DIR}/bin/utils/common.sh"
 
 BASEDIR="$SCRIPT_DIR"
-ARGS=("${@}")
 
 # Warning: Requires AWS CLI. See './aws'.
 
@@ -36,7 +35,7 @@ Loading env vars...
 EOF
 
     while IFS="" read -r p || [ -n "$p" ]; do
-        if [ $(echo "$p" | grep $1) ]; then
+        if [ "$(echo "$p" | grep "$1")" ]; then
             printf '%s\n' "$p"
             eval "$p"
         fi

--- a/bin/aws-sso-cred
+++ b/bin/aws-sso-cred
@@ -30,4 +30,4 @@ docker run -i $(get_tty_flag) --rm \
     --volume $PWD:$WORKDIR \
     --workdir $WORKDIR \
     --entrypoint /bin/bash \
-    $IMAGE -c "ssocred ${@}"
+    "$IMAGE" -c "ssocred $*"

--- a/bin/aws-sso-cred
+++ b/bin/aws-sso-cred
@@ -21,6 +21,7 @@ CONTAINER_LABELS=$(get_container_labels "aws-sso-cred" "$IMAGE")
 setup_logging "aws-sso-cred"
 
 # run from your working directory
+# shellcheck disable=SC2046  # get_tty_flag intentionally word-splits to pass -t or nothing
 docker run -i $(get_tty_flag) --rm \
     --name $CONTAINER_NAME \
     $CONTAINER_LABELS \

--- a/bin/gcloud-login
+++ b/bin/gcloud-login
@@ -33,6 +33,7 @@ CONTAINER_LABELS=$(get_container_labels "gcloud-login" "$IMAGE")
 setup_logging "gcloud-login"
 
 # run from your working directory
+# shellcheck disable=SC2046  # get_tty_flag intentionally word-splits to pass -t or nothing
 docker run -i $(get_tty_flag) \
     --platform linux/amd64 \
     --name gcloud-config \

--- a/bin/serverless
+++ b/bin/serverless
@@ -15,7 +15,7 @@ WORKDIR=/app
 IMAGE=${IMAGE:-"$MEC_IMAGE_SERVERLESS"}
 
 # via env var
-if [ -z "${STACK_NAME}"]; then
+if [ -z "${STACK_NAME}" ]; then
     STACK_NAME=development
 fi
 

--- a/bin/serverless
+++ b/bin/serverless
@@ -42,8 +42,8 @@ DOCKER_CMD="docker run -i $(get_tty_flag) --rm \
     --env AWS_PROFILE=${AWS_PROFILE} \
     --env AWS_SDK_LOAD_CONFIG=1 \
     --env STACK_NAME=${STACK_NAME} \
-    --env SLS_DEBUG="${SLS_DEBUG:-0}" \
-    --env DEBUG="${DEBUG:-0}" \
+    --env "SLS_DEBUG=${SLS_DEBUG:-0}" \
+    --env "DEBUG=${DEBUG:-0}" \
     --volume ${HOME}/.aws:/root/.aws \
     --volume ${PWD}:${WORKDIR} \
     --workdir ${WORKDIR} \

--- a/bin/utils/common.sh
+++ b/bin/utils/common.sh
@@ -66,10 +66,11 @@ is_valid_json_file() {
 # Use only for ~/.claude.json — other config files have different reset rules.
 reset_claude_config() {
     local config_file="${HOME}/.claude.json"
-    local backup="${config_file}.bak.$(date +%s)"
-    msg_warn "~/.claude.json is corrupted — backing up to $(basename "$backup") and resetting"
+    local backup
+    backup="${config_file}.bak.$(date +%s)"
+    msg_warn "$HOME/.claude.json is corrupted — backing up to $(basename "$backup") and resetting"
     cp "$config_file" "$backup"
-    > "$config_file"
+    true > "$config_file"
 }
 
 # ----------------------------------------------------------------------------

--- a/bin/utils/log-manager.sh
+++ b/bin/utils/log-manager.sh
@@ -11,6 +11,7 @@
 # ----------------------------------------------------------------------------
 LOG_FORMAT_VERSION="1.0"
 DEFAULT_LOG_DIR="${MEC_HOME:-${HOME}/.my-ez-cli}/logs"
+# shellcheck disable=SC2034  # used by sourcing scripts
 DEFAULT_CONFIG_FILE="${MEC_HOME:-${HOME}/.my-ez-cli}/config.yaml"
 
 # ----------------------------------------------------------------------------
@@ -77,7 +78,8 @@ log_session_init() {
     export LOG_SESSION_IMAGE="$IMAGE_NAME"
     export LOG_SESSION_COMMAND="$COMMAND"
     export LOG_SESSION_START_TIME="$TIMESTAMP"
-    export LOG_SESSION_CWD="$(pwd)"
+    LOG_SESSION_CWD="$(pwd)"
+    export LOG_SESSION_CWD
     export LOG_JSON_FILE="$JSON_LOG_FILE"
     export LOG_SESSION_START_EPOCH
     export LOG_ENABLED
@@ -265,7 +267,7 @@ log_cleanup() {
     load_log_config
 
     if [ -d "${LOG_DIR}/${TOOL_NAME}" ]; then
-        rm -rf "${LOG_DIR}/${TOOL_NAME}"
+        rm -rf "${LOG_DIR:?}/${TOOL_NAME}"
     fi
 }
 


### PR DESCRIPTION
## Summary

Adds 5 automated security and quality analysis tools alongside the existing Trivy scans, fixes all pre-existing ShellCheck warnings, and adds ShellCheck as a pre-commit hook.

### `.github/dependabot.yml` — dependency auto-updates
14 package ecosystem entries covering:
- `pip` (Poetry) for `services/ai/` and `services/dashboard/`
- `npm` for `services/dashboard/frontend/` (Vue 3)
- `github-actions` at root (keeps action versions current)
- `docker` base image updates for all 10 custom image directories

All set to weekly schedule, `open-pull-requests-limit: 5`, target branch `main`.

### `.github/workflows/codeql.yml` — SAST source code analysis
- Analyzes Python code in `services/ai/` and `services/dashboard/`
- Runs on push to `main`, PRs targeting `main`, and weekly (Wednesday 3 AM UTC)
- Uploads findings to GitHub Security tab

### `.github/workflows/scorecard.yml` — OSSF repo security posture
- Evaluates branch protection, CI hygiene, signed releases, dependency pinning, etc.
- Runs on push to `main` and weekly (Sunday 3 AM UTC)
- Uploads SARIF to GitHub Security tab

### `.github/workflows/shellcheck.yml` — shell script linting
- Lints all scripts under `bin/` (extensionless bash scripts)
- Runs on push to `main` and PRs targeting `main`
- Uses `ludeeus/action-shellcheck` (most actively maintained GH Action integration)
- Severity threshold: `warning`

### `.github/workflows/hadolint.yml` — Dockerfile linting
- Lints all 10 Dockerfiles under `docker/`
- Runs on push to `main` and PRs targeting `main` (path filter: `docker/**`)
- Uses `hadolint/hadolint-action@v3.1.0` (official Hadolint org action)

### ShellCheck warning fixes (`bin/`)
Fixed all 15 pre-existing ShellCheck warnings across 7 files:
- `log-manager.sh`: SC2034 disable, SC2155 split declare/assign, SC2115 guard rm -rf
- `common.sh`: SC2155 split declare/assign, SC2088 use $HOME not tilde, SC2188 add true before redirection
- `gcloud-login`: SC2046 disable for intentional word-split
- `aws-saml-okta`: SC2034 remove dead `factor_id` variable, SC2064 fix trap quoting
- `serverless`: SC2027 quote env var assignments
- `aws-sso-cred`: SC2046 disable for intentional word-split
- `aws-sso`: SC2034 remove unused ARGS array, SC2046 quote grep arg

### Pre-commit hook — ShellCheck
- Migrated `services/ai/.pre-commit-config.yaml` → `.pre-commit-config.yaml` (project root)
  — config was already project-wide; living under `services/ai/` was misleading
- Added `shellcheck-py/shellcheck-py` hook targeting `bin/` with `--severity=warning`
- Updated `.git/hooks/pre-commit` to reference new root config path

## Test plan

- [x] ShellCheck CI passes with all warnings fixed
- [ ] Trigger CodeQL workflow via `workflow_dispatch` — verify Security tab results
- [ ] Trigger Scorecard workflow via `workflow_dispatch` — verify Security tab results
- [ ] Trigger ShellCheck workflow via `workflow_dispatch` — verify `bin/` scripts are linted
- [ ] Trigger Hadolint workflow via `workflow_dispatch` — verify Dockerfiles are linted
- [ ] Verify Dependabot is active in repo Settings → Security → Dependabot
- [ ] Run `pre-commit run shellcheck --all-files` locally — verify it passes

Closes #150