### PR TITLE
ci: bump deprecated Node.js 20 actions to Node.js 24-compatible versions

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -1,0 +1,28 @@
+# CI Workflow Standards
+
+## Always use current GitHub Actions versions
+
+When writing or editing any `.github/workflows/` file, always use the latest major version of each action. Node.js 20-based action versions are deprecated (forced to Node.js 24 June 2026, removed September 2026).
+
+**Current latest versions (as of 2026-05):**
+- `actions/checkout@v6`
+- `actions/upload-artifact@v7`
+- `actions/download-artifact@v8`
+- `actions/setup-node@v6`
+- `actions/setup-python@v6`
+- `actions/cache@v5`
+- `docker/setup-qemu-action@v4`
+- `docker/setup-buildx-action@v4`
+- `docker/login-action@v4`
+- `docker/metadata-action@v6`
+- `docker/build-push-action@v7`
+- `aquasecurity/trivy-action@v0.36.0`
+- `github/codeql-action/*@v4`
+- `ossf/scorecard-action@v2.4.3`
+- `hadolint/hadolint-action@v3.3.0`
+
+**How to apply:**
+- Before adding any `uses:` line, verify the action's latest release: `gh api repos/<owner>/<repo>/releases/latest --jq '.tag_name'`
+- `v4` for `actions/checkout`, `upload-artifact`, or `download-artifact` is outdated — use the versions above
+- When GitHub warns "Node.js 20 actions are deprecated", bump the action version — never use `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` or `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` as workarounds
+- Upload and download artifact versions must be kept in sync (both must be ≥ v4 to share artifacts across jobs)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -69,7 +69,7 @@ jobs:
           vuln-type: os,library
 
       - name: Upload JSON artifacts for triage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: trivy-json-${{ matrix.tool }}
           path: |

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Find latest security-scan run
         id: scan-run
@@ -46,7 +46,7 @@ jobs:
           echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
 
       - name: Download Trivy artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: trivy-json-${{ matrix.tool }}
           path: /tmp/trivy


### PR DESCRIPTION
## Summary

- `security-scan.yml`: `actions/upload-artifact@v4` → `v7`
- `security-triage.yml`: `actions/checkout@v4` → `v6`, `actions/download-artifact@v4` → `v8`
- Adds `.claude/rules/ci-workflows.md` with a pinlist of current action versions and a rule to always verify before adding a `uses:` line

Fixes deprecation warnings reported in the Trivy and Triage workflow runs. Node.js 20 actions are forced to Node.js 24 starting June 2nd, 2026 and removed September 16th, 2026.

## Test plan

- [ ] Verify Security Scan workflow runs cleanly (no Node.js 20 deprecation warnings on `upload-artifact`)
- [ ] Verify Security Triage workflow runs cleanly (no Node.js 20 deprecation warnings on `checkout` and `download-artifact`)