### PR TITLE
fix(docker): pin claude image to node:24-slim to fix npm upgrade failure

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25-slim
+FROM node:24-slim
 
 # Metadata
 LABEL com.my-ez-cli.project="my-ez-cli"


### PR DESCRIPTION
## Summary
- The `build-claude` CI job was failing: `docker/claude/Dockerfile` was bumped to `node:25-slim` in #185, which bundles npm 12.0.2
- `npm install -g npm@latest` now requires node `^22.22.2 || ^24.15.0 || >=26.0.0`, so the upgrade step fails with `EBADENGINE` under node 25
- Reverted the base image to `node:24-slim` (LTS), which satisfies the engine requirement

## Test plan
- [x] `docker build -f docker/claude/Dockerfile docker/claude` succeeds locally
- [ ] CI `build-claude` job passes